### PR TITLE
feat: remark-mdx is not compatible with normal markdown syntaxes

### DIFF
--- a/packages/eslint-mdx/src/parser.ts
+++ b/packages/eslint-mdx/src/parser.ts
@@ -334,12 +334,20 @@ export class Parser {
 
     const value = node.value as string
 
+    const { loc, start, end } = normalizePosition(node.position)
+
     // fix #4
     if (isComment(value)) {
+      const comment = COMMENT_CONTENT_REGEX.exec(value)[2]
+      this._ast.comments.push({
+        type: 'Block',
+        value: comment,
+        loc,
+        range: [start, end],
+      })
       return
     }
 
-    const { loc, start } = normalizePosition(node.position)
     const startLine = loc.start.line - 1 // ! line is 1-indexed, change to 0-indexed to simplify usage
 
     let program: AST.Program

--- a/packages/eslint-mdx/src/parser.ts
+++ b/packages/eslint-mdx/src/parser.ts
@@ -24,7 +24,8 @@ import {
   ParserOptions,
 } from './types'
 
-export const mdxProcessor = unified().use(remarkParse).use(remarkMdx).freeze()
+export const mdProcessor = unified().use(remarkParse).freeze()
+export const mdxProcessor = mdProcessor().use(remarkMdx).freeze()
 
 export const AST_PROPS = ['body', 'comments', 'tokens'] as const
 export const ES_NODE_TYPES: readonly string[] = ['export', 'import', 'jsx']
@@ -161,7 +162,7 @@ export class Parser {
       return this._eslintParse(code, options)
     }
 
-    const root = mdxProcessor.parse(code) as Parent
+    const root = (isMdx ? mdxProcessor : mdProcessor).parse(code) as Parent
 
     this._ast = {
       ...normalizePosition(root.position),

--- a/packages/eslint-plugin-mdx/src/rules/helper.ts
+++ b/packages/eslint-plugin-mdx/src/rules/helper.ts
@@ -41,7 +41,7 @@ export const requirePkg = <T>(
 let searchSync: (searchFrom?: string) => CosmiconfigResult
 let remarkProcessor: Processor
 
-export const getRemarkProcessor = (searchFrom: string) => {
+export const getRemarkProcessor = (searchFrom: string, isMdx: boolean) => {
   if (!searchSync) {
     searchSync = cosmiconfigSync('remark', {
       packageProp: 'remarkConfig',
@@ -66,6 +66,12 @@ export const getRemarkProcessor = (searchFrom: string) => {
     // just ignore if the package does not exist
   }
 
+  const initProcessor = remarkProcessor().use({ settings }).use(remarkStringify)
+
+  if (isMdx) {
+    initProcessor.use(remarkMdx)
+  }
+
   return plugins
     .reduce((processor, pluginWithSettings) => {
       const [plugin, ...pluginSettings] = Array.isArray(pluginWithSettings)
@@ -78,6 +84,6 @@ export const getRemarkProcessor = (searchFrom: string) => {
           : plugin,
         ...pluginSettings,
       )
-    }, remarkProcessor().use({ settings }).use(remarkStringify).use(remarkMdx))
+    }, initProcessor)
     .freeze()
 }

--- a/packages/eslint-plugin-mdx/src/rules/remark.ts
+++ b/packages/eslint-plugin-mdx/src/rules/remark.ts
@@ -23,21 +23,21 @@ export const remark: Rule.RuleModule = {
     const filename = context.getFilename()
     const extname = path.extname(filename)
     const sourceCode = context.getSourceCode()
-    const extensions = new Set(
-      DEFAULT_EXTENSIONS.concat(
-        context.parserOptions.extensions || [],
-        MARKDOWN_EXTENSIONS,
-        context.parserOptions.markdownExtensions || [],
-      ),
+    const options = context.parserOptions
+    const isMdx = DEFAULT_EXTENSIONS.concat(options.extensions || []).includes(
+      extname,
     )
+    const isMarkdown = MARKDOWN_EXTENSIONS.concat(
+      options.markdownExtensions || [],
+    ).includes(extname)
     return {
       Program(node) {
         /* istanbul ignore if */
-        if (!extensions.has(extname)) {
+        if (!isMdx && !isMarkdown) {
           return
         }
         const sourceText = sourceCode.getText(node)
-        const remarkProcessor = getRemarkProcessor(filename)
+        const remarkProcessor = getRemarkProcessor(filename, isMdx)
         const file = vfile({
           path: filename,
           contents: sourceText,

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -116,4 +116,6 @@ Header <header>
 "
 `;
 
+exports[`fixtures should match all snapshots: remark.md 1`] = `undefined`;
+
 exports[`fixtures should match all snapshots: remark.mdx 1`] = `undefined`;

--- a/test/fixtures/remark.md
+++ b/test/fixtures/remark.md
@@ -1,7 +1,7 @@
 _Hello_, **world**!
 
-### Code Splitting
+<!--lint disable no-literal-urls-->
 
-<!-- eslint-disable mdx/remark -->
+### Code Splitting
 
 This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,17 +1758,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@jest/types@^26.1.0":
-  version "26.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.1.0.tgz#f8afaaaeeb23b5cad49dd1f7779689941dcb6057"
-  integrity sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-
-"@jest/types@^26.2.0":
+"@jest/types@^26.1.0", "@jest/types@^26.2.0":
   version "26.2.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.2.0.tgz#b28ca1fb517a4eb48c0addea7fcd9edc4ab45721"
   integrity sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==
@@ -3056,12 +3046,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
-"@types/node@*", "@types/node@>= 8":
-  version "14.0.22"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.22.tgz#23ea4d88189cec7d58f9e6b66f786b215eb61bdc"
-  integrity sha512-emeGcJvdiZ4Z3ohbmw93E/64jRzUHAItSHt8nF7M4TGgQTiWqFVGB8KNpLGFmUHmHLvjvBgFwVlqNcq+VuGv9g==
-
-"@types/node@^14.0.27":
+"@types/node@*", "@types/node@>= 8", "@types/node@^14.0.27":
   version "14.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
@@ -3098,15 +3083,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.9.43"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.43.tgz#c287f23f6189666ee3bebc2eb8d0f84bcb6cdb6b"
-  integrity sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@^16.9.44":
+"@types/react@*", "@types/react@^16.9.44":
   version "16.9.44"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.44.tgz#da84b179c031aef67dc92c33bd3401f1da2fa3bc"
   integrity sha512-BtLoJrXdW8DVZauKP+bY4Kmiq7ubcJq+H/aCpRfvPF7RAT3RwR73Sg8szdc2YasbAlWBDrQ6Q+AFM0KwtQY+WQ==
@@ -7758,24 +7735,13 @@ jest-snapshot@^26.1.0:
     pretty-format "^26.1.0"
     semver "^7.3.2"
 
-jest-util@26.x:
+jest-util@26.x, jest-util@^26.1.0:
   version "26.2.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.2.0.tgz#0597d2a27c559340957609f106c408c17c1d88ac"
   integrity sha512-YmDwJxLZ1kFxpxPfhSJ0rIkiZOM0PQbRcfH0TzJOhqCisCAsI1WcmoQqO83My9xeVA2k4n+rzg2UuexVKzPpig==
   dependencies:
     "@jest/types" "^26.2.0"
     "@types/node" "*"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^2.0.0"
-    micromatch "^4.0.2"
-
-jest-util@^26.1.0:
-  version "26.1.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.1.0.tgz#80e85d4ba820decacf41a691c2042d5276e5d8d8"
-  integrity sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==
-  dependencies:
-    "@jest/types" "^26.1.0"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
     is-ci "^2.0.0"


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

As `remark-mdx@v2` is [not compatible](https://github.com/mdx-js/mdx/issues/1042) with normal markdown comment syntaxes anymore, so markdown and mdx files should be processed specifically.

@johno @wooorm 