### PR TITLE
fix: code block in jsx should be ignored

### DIFF
--- a/packages/eslint-mdx/src/traverse.ts
+++ b/packages/eslint-mdx/src/traverse.ts
@@ -21,7 +21,11 @@ export class Traverse {
     return {
       type: 'jsx',
       data: jsxNodes[0].data,
-      value: jsxNodes.reduce((acc, { value }) => (acc += value), ''),
+      value: jsxNodes.reduce(
+        // code block should be ignored
+        (acc, { type, value }) => (acc += type === 'code' ? '' : value),
+        '',
+      ),
       position: {
         start: jsxNodes[0].position.start,
         end: last(jsxNodes).position.end,

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -79,6 +79,29 @@ Here's a YouTube shortcode:
 "
 `;
 
+exports[`fixtures should match all snapshots: details.mdx 1`] = `
+"<details>
+
+<summary>Override element states</summary>
+
+\`\`\`jsx
+/* colored-button.jsx */
+
+import styles from './colored-button.module.css'
+
+function ColoredButton({ text, color }) {
+  return (
+    <Button className={styles.coloredButton} style={{ '--color': color }} naked>
+      {text}
+    </Button>
+  )
+}
+\`\`\`
+
+</details>
+"
+`;
+
 exports[`fixtures should match all snapshots: markdown.md 1`] = `undefined`;
 
 exports[`fixtures should match all snapshots: no-jsx-html-comments.mdx 1`] = `

--- a/test/fixtures/details.mdx
+++ b/test/fixtures/details.mdx
@@ -1,0 +1,19 @@
+<details>
+
+<summary >Override element states</summary>
+
+```jsx
+/* colored-button.jsx */
+
+import styles from './colored-button.module.css'
+
+function ColoredButton({ text, color }) {
+  return (
+    <Button className={styles.coloredButton} style={{ '--color': color }} naked>
+      {text}
+    </Button>
+  )
+}
+```
+
+</details>


### PR DESCRIPTION
Partially fix #207

Code blocks in jsx should always be ignored, but I don't know if it is good to drop them in AST, or is there any better way?

Additionally, `<details><summary >Override element states</summary>` is parsed as a single jsx node from `remark-mdx`, it could not be handled correctly at https://github.com/mdx-js/eslint-mdx/blob/master/packages/eslint-mdx/src/traverse.ts#L41 which expects `<details>` and `<summary >Override element states</summary>` separately, is that possible to do it in `remark-mdx`? @wooorm 

The temporary workaround is:

```mdx
<details>

<summary >Override element states</summary>

</details>
```

What means that depends on user to make sure that `<details>` is a single jsx node.

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
