### PR TITLE
feat: experimentally support linting code blocks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,5 +8,14 @@ module.exports = {
   rules: {
     // `strictNullChecks` is required
     '@typescript-eslint/no-unnecessary-condition': 0,
+    'mdx/code-block': 2,
   },
+  overrides: [
+    {
+      files: '**/*.{md,mdx}/**',
+      rules: {
+        'prettier/prettier': 0,
+      },
+    },
+  ],
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org)
 [![codechecks.io](https://raw.githubusercontent.com/codechecks/docs/master/images/badges/badge-default.svg?sanitize=true)](https://codechecks.io)
 
-> [ESLint][] Parser/Plugin for [MDX][], helps you lint all ES syntaxes excluding `code` block of course.
+> [ESLint][] Parser/Plugin for [MDX][], helps you lint all ES syntaxes.
+> Linting `code` blocks can be enabled with `mdx/code-block` rule too!
 > Work perfectly with `eslint-plugin-import`, `eslint-plugin-prettier` or any other eslint plugins.
 > And also can be integrated with [remark-lint][] plugins to lint markdown syntaxes.
 
@@ -38,6 +39,7 @@
   - [mdx/no-unescaped-entities](#mdxno-unescaped-entities)
   - [mdx/no-unused-expressions](#mdxno-unused-expressions)
   - [mdx/remark](#mdxremark)
+  - [mdx/code-block](#mdxcode-block)
 - [Prettier Integration](#prettier-integration)
 - [Changelog](#changelog)
 - [License](#license)
@@ -125,12 +127,10 @@ npm i -D eslint-plugin-mdx
               ],
             },
           },
-          Object.assign(
-            {
-              files: ['*.mdx'],
-            },
-            configs.overrides,
-          ),
+          {
+            files: ['*.mdx'],
+            ...configs.overrides,
+          },
         ],
       }
       ```
@@ -166,17 +166,21 @@ _Fixable_: HTML style comments in jsx block is invalid, this rule will help you 
 
 ### mdx/no-unescaped-entities
 
-Inline JSX like `Inline <Component />` is supported by [MDX][], but rule `react/no-unescaped-entities` from [eslint-plugin-react][] is incompatible with it, `mdx/no-unescaped-entities` is the replacement.
+Inline JSX like `Inline <Component />` is supported by [MDX][], but rule `react/no-unescaped-entities` from [eslint-plugin-react][] is incompatible with it, `mdx/no-unescaped-entities` is the replacement, so make sure that you've turned off the original `no-unescaped-entities` rule.
 
 ### mdx/no-unused-expressions
 
-[MDX][] can render `jsx` block automatically without exporting them, but [ESLint][] will report `no-unused-expressions` issue which could be unexpected, this rule is a replacement of it, so make sure that you've turned off the original `no-unused-expressions` rule.
+[MDX][] can render `jsx` block automatically without exporting them, but [ESLint][] will report `no-unused-expressions` issue which could be unexpected, this rule is the replacement, so make sure that you've turned off the original `no-unused-expressions` rule.
 
 ### mdx/remark
 
 _possible fixable depends on your remark plugins_:
 
 Integration with [remark-lint][] plugins, it will read [remark's configuration](https://github.com/remarkjs/remark/tree/master/packages/remark-cli#remark-cli) automatically via [cosmiconfig][]. But `.remarkignore` will not be respected, you should use `.eslintignore` instead.
+
+### mdx/code-block
+
+_Fixable_: This rule is **experimental** currently, you can try it and give us feedbacks.
 
 ## Prettier Integration
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "run-p build:*",
     "build:r": "r -p",
     "build:ts": "tsc -b",
+    "clean": "rimraf packages/*/{lib,*.tsbuildinfo} node_modules/@1stg/eslint-config/node_modules",
     "lint": "run-p lint:*",
     "lint:es": "cross-env PARSER_NO_WATCH=true eslint . --cache --ext js,md,ts -f friendly",
     "lint:ts": "tslint -p . -t stylish",

--- a/packages/eslint-mdx/README.md
+++ b/packages/eslint-mdx/README.md
@@ -22,7 +22,8 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org)
 [![codechecks.io](https://raw.githubusercontent.com/codechecks/docs/master/images/badges/badge-default.svg?sanitize=true)](https://codechecks.io)
 
-> [ESLint][] Parser/Plugin for [MDX][], helps you lint all ES syntaxes excluding `code` block of course.
+> [ESLint][] Parser/Plugin for [MDX][], helps you lint all ES syntaxes.
+> Linting `code` blocks can be enabled with `mdx/code-block` rule too!
 > Work perfectly with `eslint-plugin-import`, `eslint-plugin-prettier` or any other eslint plugins.
 > And also can be integrated with [remark-lint][] plugins to lint markdown syntaxes.
 
@@ -38,6 +39,7 @@
   - [mdx/no-unescaped-entities](#mdxno-unescaped-entities)
   - [mdx/no-unused-expressions](#mdxno-unused-expressions)
   - [mdx/remark](#mdxremark)
+  - [mdx/code-block](#mdxcode-block)
 - [Prettier Integration](#prettier-integration)
 - [Changelog](#changelog)
 - [License](#license)
@@ -125,12 +127,10 @@ npm i -D eslint-plugin-mdx
               ],
             },
           },
-          Object.assign(
-            {
-              files: ['*.mdx'],
-            },
-            configs.overrides,
-          ),
+          {
+            files: ['*.mdx'],
+            ...configs.overrides,
+          },
         ],
       }
       ```
@@ -166,17 +166,21 @@ _Fixable_: HTML style comments in jsx block is invalid, this rule will help you 
 
 ### mdx/no-unescaped-entities
 
-Inline JSX like `Inline <Component />` is supported by [MDX][], but rule `react/no-unescaped-entities` from [eslint-plugin-react][] is incompatible with it, `mdx/no-unescaped-entities` is the replacement.
+Inline JSX like `Inline <Component />` is supported by [MDX][], but rule `react/no-unescaped-entities` from [eslint-plugin-react][] is incompatible with it, `mdx/no-unescaped-entities` is the replacement, so make sure that you've turned off the original `no-unescaped-entities` rule.
 
 ### mdx/no-unused-expressions
 
-[MDX][] can render `jsx` block automatically without exporting them, but [ESLint][] will report `no-unused-expressions` issue which could be unexpected, this rule is a replacement of it, so make sure that you've turned off the original `no-unused-expressions` rule.
+[MDX][] can render `jsx` block automatically without exporting them, but [ESLint][] will report `no-unused-expressions` issue which could be unexpected, this rule is the replacement, so make sure that you've turned off the original `no-unused-expressions` rule.
 
 ### mdx/remark
 
 _possible fixable depends on your remark plugins_:
 
 Integration with [remark-lint][] plugins, it will read [remark's configuration](https://github.com/remarkjs/remark/tree/master/packages/remark-cli#remark-cli) automatically via [cosmiconfig][]. But `.remarkignore` will not be respected, you should use `.eslintignore` instead.
+
+### mdx/code-block
+
+_Fixable_: This rule is **experimental** currently, you can try it and give us feedbacks.
 
 ## Prettier Integration
 

--- a/packages/eslint-mdx/src/helper.ts
+++ b/packages/eslint-mdx/src/helper.ts
@@ -5,11 +5,14 @@ import { parse as esParse } from 'espree'
 
 import {
   Arrayable,
+  CodeBlockNode,
   JsxNode,
   JsxType,
   JsxTypes,
+  Node,
   ParserFn,
   ParserOptions,
+  ValueOf,
 } from './types'
 
 export const FALLBACK_PARSERS = [
@@ -140,3 +143,71 @@ export const first = <T>(items: T[] | readonly T[]) => items && items[0]
 
 export const last = <T>(items: T[] | readonly T[]) =>
   items && items[items.length - 1]
+
+export const PARSABLE_LANGUAGES = [
+  // es
+  'cjs',
+  'javascript',
+  'javascriptreact',
+  'js',
+  'jsx',
+  'mjs',
+  // remark
+  'markdown',
+  'md',
+  'mdown',
+  'mdx',
+  'mkdn',
+  // ts
+  'ts',
+  'tsx',
+  'typescript',
+  'typescriptreact',
+] as const
+
+export const SHORT_PARSABLE_LANGUAGES = [
+  // es
+  'cjs',
+  'js',
+  'jsx',
+  'mjs',
+  // remark
+  'md',
+  'mdx',
+  // ts
+  'ts',
+  'tsx',
+] as const
+
+// eslint-disable-next-line @typescript-eslint/no-type-alias
+export type ParsableLanguage = ValueOf<typeof PARSABLE_LANGUAGES>
+
+// eslint-disable-next-line @typescript-eslint/no-type-alias
+export type ShortParsableLanguage = ValueOf<typeof SHORT_PARSABLE_LANGUAGES>
+
+export const LANGUAGES_MAPPER: Partial<
+  Record<ParsableLanguage, ShortParsableLanguage>
+> = {
+  javascript: 'js',
+  javascriptreact: 'jsx',
+  typescript: 'ts',
+  typescriptreact: 'tsx',
+  markdown: 'md',
+  mdown: 'md',
+  mkdn: 'md',
+}
+
+export const getShortLanguage = (lang: string) => {
+  const parsableLanguage = last(
+    lang.split(/\s/)[0].split('.'),
+  ).toLowerCase() as ParsableLanguage
+  return (
+    LANGUAGES_MAPPER[parsableLanguage] ||
+    (parsableLanguage as ShortParsableLanguage)
+  )
+}
+
+export const isCodeBlockNode = (node: Node): node is CodeBlockNode =>
+  node.type === 'code' &&
+  typeof node.lang === 'string' &&
+  SHORT_PARSABLE_LANGUAGES.includes(getShortLanguage(node.lang))

--- a/packages/eslint-mdx/src/types.ts
+++ b/packages/eslint-mdx/src/types.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-type-alias */
 import { AST, Linter } from 'eslint'
 
+import { ParsableLanguage } from './helper'
+
 export type JSXElement = import('@babel/types').JSXElement
 export type JSXFragment = import('@babel/types').JSXFragment
 export type Node = import('unist').Node
@@ -58,6 +60,22 @@ export interface Comment {
   origin: string
 }
 
+export type ValueOf<T> = T extends {
+  [key: string]: infer M
+}
+  ? M
+  : T extends {
+      [key: number]: infer N
+    }
+  ? N
+  : never
+
+export interface CodeBlockNode extends Node {
+  lang: ParsableLanguage
+  value: string
+}
+
 export interface ParserServices {
   JSXElementsWithHTMLComments: Node[]
+  codeBlocks: CodeBlockNode[]
 }

--- a/packages/eslint-plugin-mdx/README.md
+++ b/packages/eslint-plugin-mdx/README.md
@@ -22,7 +22,8 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org)
 [![codechecks.io](https://raw.githubusercontent.com/codechecks/docs/master/images/badges/badge-default.svg?sanitize=true)](https://codechecks.io)
 
-> [ESLint][] Parser/Plugin for [MDX][], helps you lint all ES syntaxes excluding `code` block of course.
+> [ESLint][] Parser/Plugin for [MDX][], helps you lint all ES syntaxes.
+> Linting `code` blocks can be enabled with `mdx/code-block` rule too!
 > Work perfectly with `eslint-plugin-import`, `eslint-plugin-prettier` or any other eslint plugins.
 > And also can be integrated with [remark-lint][] plugins to lint markdown syntaxes.
 
@@ -38,6 +39,7 @@
   - [mdx/no-unescaped-entities](#mdxno-unescaped-entities)
   - [mdx/no-unused-expressions](#mdxno-unused-expressions)
   - [mdx/remark](#mdxremark)
+  - [mdx/code-block](#mdxcode-block)
 - [Prettier Integration](#prettier-integration)
 - [Changelog](#changelog)
 - [License](#license)
@@ -125,12 +127,10 @@ npm i -D eslint-plugin-mdx
               ],
             },
           },
-          Object.assign(
-            {
-              files: ['*.mdx'],
-            },
-            configs.overrides,
-          ),
+          {
+            files: ['*.mdx'],
+            ...configs.overrides,
+          },
         ],
       }
       ```
@@ -166,17 +166,21 @@ _Fixable_: HTML style comments in jsx block is invalid, this rule will help you 
 
 ### mdx/no-unescaped-entities
 
-Inline JSX like `Inline <Component />` is supported by [MDX][], but rule `react/no-unescaped-entities` from [eslint-plugin-react][] is incompatible with it, `mdx/no-unescaped-entities` is the replacement.
+Inline JSX like `Inline <Component />` is supported by [MDX][], but rule `react/no-unescaped-entities` from [eslint-plugin-react][] is incompatible with it, `mdx/no-unescaped-entities` is the replacement, so make sure that you've turned off the original `no-unescaped-entities` rule.
 
 ### mdx/no-unused-expressions
 
-[MDX][] can render `jsx` block automatically without exporting them, but [ESLint][] will report `no-unused-expressions` issue which could be unexpected, this rule is a replacement of it, so make sure that you've turned off the original `no-unused-expressions` rule.
+[MDX][] can render `jsx` block automatically without exporting them, but [ESLint][] will report `no-unused-expressions` issue which could be unexpected, this rule is the replacement, so make sure that you've turned off the original `no-unused-expressions` rule.
 
 ### mdx/remark
 
 _possible fixable depends on your remark plugins_:
 
 Integration with [remark-lint][] plugins, it will read [remark's configuration](https://github.com/remarkjs/remark/tree/master/packages/remark-cli#remark-cli) automatically via [cosmiconfig][]. But `.remarkignore` will not be respected, you should use `.eslintignore` instead.
+
+### mdx/code-block
+
+_Fixable_: This rule is **experimental** currently, you can try it and give us feedbacks.
 
 ## Prettier Integration
 

--- a/packages/eslint-plugin-mdx/src/processors/remark.ts
+++ b/packages/eslint-plugin-mdx/src/processors/remark.ts
@@ -13,19 +13,35 @@ export const remark = {
             ruleId: eslintRuleId,
             severity: eslintSeverity,
           } = lintMessage
-          if (eslintRuleId !== 'mdx/remark') {
-            return lintMessage
-          }
 
-          const { source, ruleId, reason, severity } = JSON.parse(
-            message,
-          ) as RemarkLintMessage
+          switch (eslintRuleId) {
+            case 'mdx/remark': {
+              const { source, ruleId, reason, severity } = JSON.parse(
+                message,
+              ) as RemarkLintMessage
 
-          return {
-            ...lintMessage,
-            ruleId: `${source}-${ruleId}`,
-            message: reason,
-            severity: Math.max(eslintSeverity, severity) as Linter.Severity,
+              return {
+                ...lintMessage,
+                ruleId: `${source}-${ruleId}`,
+                message: reason,
+                severity: Math.max(eslintSeverity, severity) as Linter.Severity,
+              }
+            }
+            case 'mdx/code-block': {
+              const originalLintMessage = JSON.parse(
+                message,
+              ) as Linter.LintMessage
+              return {
+                ...originalLintMessage,
+                severity: Math.min(
+                  eslintSeverity,
+                  originalLintMessage.severity,
+                ) as Linter.Severity,
+              }
+            }
+            default: {
+              return lintMessage
+            }
           }
         }),
       )

--- a/packages/eslint-plugin-mdx/src/rules/code-block.ts
+++ b/packages/eslint-plugin-mdx/src/rules/code-block.ts
@@ -1,0 +1,124 @@
+import path from 'path'
+
+import { AST, CLIEngine, Linter, Rule } from 'eslint'
+import { ParserServices, getShortLanguage } from 'eslint-mdx'
+
+import { getRangeByLoc, parseContext } from './helper'
+
+export const codeBlock: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Lint code blocks',
+      category: 'Stylistic Issues',
+      recommended: true,
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    const { isMdx, isMarkdown, filename, sourceCode } = parseContext(context)
+    // eslint-disable-next-line sonar/deprecation -- w
+    const cli = new CLIEngine({
+      ignore: false,
+    })
+    return {
+      // eslint-disable-next-line sonarjs/cognitive-complexity
+      Program() {
+        if (!isMdx && !isMarkdown) {
+          return
+        }
+
+        const { codeBlocks } = context.parserServices as ParserServices
+
+        // eslint-disable-next-line unicorn/no-array-for-each
+        codeBlocks.forEach(({ lang, value, position: { start } }, index) => {
+          const language = getShortLanguage(lang)
+          const { results } = cli.executeOnText(
+            value,
+            path.resolve(filename, `${index}.${language}`),
+          )
+          for (const { messages } of results) {
+            for (const message of messages) {
+              let {
+                line = 1,
+                column = 1,
+                endLine,
+                endColumn,
+                fix,
+                suggestions,
+              } = message
+              const hasEnd = endLine != null && endColumn != null
+
+              line += start.line
+              column += start.column - 1
+
+              let range: [number, number]
+
+              const startPosition = {
+                line,
+                column,
+              }
+
+              let loc:
+                | AST.SourceLocation
+                | { line: number; column: number } = startPosition
+
+              let offset: number
+
+              if (hasEnd) {
+                endLine += start.line
+                endColumn += start.column - 1
+
+                loc = {
+                  start: loc,
+                  end: { line: endLine, column: endColumn },
+                }
+
+                range = getRangeByLoc(sourceCode.text, loc)
+
+                if (fix) {
+                  const offsetStart = range[0] - fix.range[0]
+                  const offsetEnd = range[1] - fix.range[1]
+                  // should always be true, just for robustness
+                  /* istanbul ignore else */
+                  if (offsetStart === offsetEnd) {
+                    offset = offsetStart
+                  }
+                }
+              }
+
+              const lintMessage: Linter.LintMessage = {
+                ...message,
+                ...startPosition,
+                endLine: hasEnd ? endLine : null,
+                endColumn: hasEnd ? endColumn : null,
+                fix: range &&
+                  fix && {
+                    range,
+                    text: fix.text,
+                  },
+                suggestions:
+                  // FIXME: find a better way to support suggestions with correct range
+                  /* istanbul ignore next */
+                  !suggestions || offset == null
+                    ? null
+                    : suggestions.map(({ fix: { range, text }, ...rest }) => ({
+                        fix: {
+                          range: [range[0] + offset, range[1] + offset],
+                          text,
+                        },
+                        ...rest,
+                      })),
+              }
+
+              context.report({
+                message: JSON.stringify(lintMessage),
+                loc,
+              })
+            }
+          }
+        })
+      },
+    }
+  },
+}

--- a/packages/eslint-plugin-mdx/src/rules/index.ts
+++ b/packages/eslint-plugin-mdx/src/rules/index.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from './code-block'
 import { noJsxHtmlComments } from './no-jsx-html-comments'
 import { noUnescapedEntities } from './no-unescaped-entities'
 import { noUnusedExpressions } from './no-unused-expressions'
@@ -6,9 +7,16 @@ import { remark } from './remark'
 export * from './helper'
 export * from './types'
 
-export { noJsxHtmlComments, noUnescapedEntities, noUnusedExpressions, remark }
+export {
+  codeBlock,
+  noJsxHtmlComments,
+  noUnescapedEntities,
+  noUnusedExpressions,
+  remark,
+}
 
 export const rules = {
+  'code-block': codeBlock,
   'no-jsx-html-comments': noJsxHtmlComments,
   'no-unescaped-entities': noUnescapedEntities,
   'no-unused-expressions': noUnusedExpressions,

--- a/packages/eslint-plugin-mdx/src/rules/no-jsx-html-comments.ts
+++ b/packages/eslint-plugin-mdx/src/rules/no-jsx-html-comments.ts
@@ -19,8 +19,9 @@ export const noJsxHtmlComments: Rule.RuleModule = {
   create(context) {
     return {
       ExpressionStatement(node: ExpressionStatementWithParent) {
-        const invalidNodes = (context.parserServices as ParserServices)
-          .JSXElementsWithHTMLComments
+        const {
+          JSXElementsWithHTMLComments: invalidNodes,
+        } = context.parserServices as ParserServices
 
         if (
           !JSX_TYPES.includes(node.expression.type as JsxType) ||

--- a/packages/eslint-plugin-mdx/src/rules/remark.ts
+++ b/packages/eslint-plugin-mdx/src/rules/remark.ts
@@ -1,10 +1,7 @@
-import path from 'path'
-
 import { Rule } from 'eslint'
-import { DEFAULT_EXTENSIONS, MARKDOWN_EXTENSIONS } from 'eslint-mdx'
 import vfile from 'vfile'
 
-import { getRemarkProcessor } from './helper'
+import { getRemarkProcessor, parseContext } from './helper'
 import { RemarkLintMessage } from './types'
 
 export const remark: Rule.RuleModule = {
@@ -18,19 +15,7 @@ export const remark: Rule.RuleModule = {
     fixable: 'code',
   },
   create(context) {
-    const filename = context.getFilename()
-    const extname = path.extname(filename)
-    const sourceCode = context.getSourceCode()
-    const options = context.parserOptions as {
-      extensions: string[]
-      markdownExtensions: string[]
-    }
-    const isMdx = DEFAULT_EXTENSIONS.concat(options.extensions || []).includes(
-      extname,
-    )
-    const isMarkdown = MARKDOWN_EXTENSIONS.concat(
-      options.markdownExtensions || [],
-    ).includes(extname)
+    const { isMdx, isMarkdown, filename, sourceCode } = parseContext(context)
     return {
       // eslint-disable-next-line sonarjs/cognitive-complexity
       Program(node) {

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -81,6 +81,154 @@ Array [
 ]
 `;
 
+exports[`fixtures should match all snapshots: code-block.md 1`] = `
+Array [
+  Object {
+    "column": 8,
+    "endColumn": 23,
+    "endLine": 2,
+    "line": 2,
+    "message": "Unexpected var, use let or const instead.",
+    "messageId": "unexpectedVar",
+    "nodeType": "VariableDeclaration",
+    "ruleId": "no-var",
+    "severity": 1,
+    "suggestions": null,
+  },
+  Object {
+    "column": 21,
+    "endColumn": 27,
+    "endLine": 4,
+    "line": 4,
+    "message": "Prefer the spread operator over \`Array#concat(…)\`.",
+    "messageId": "array-concat",
+    "nodeType": "Identifier",
+    "ruleId": "unicorn/prefer-spread",
+    "severity": 1,
+    "suggestions": null,
+  },
+  Object {
+    "column": 26,
+    "endColumn": 31,
+    "endLine": 12,
+    "line": 12,
+    "message": "'React' must be in scope when using JSX",
+    "nodeType": "JSXOpeningElement",
+    "ruleId": "react/react-in-jsx-scope",
+    "severity": 1,
+    "suggestions": null,
+  },
+  Object {
+    "column": 33,
+    "endColumn": null,
+    "endLine": null,
+    "line": 12,
+    "message": "\`>\` can be escaped with \`&gt;\`.",
+    "nodeType": "JSXText",
+    "ruleId": "react/no-unescaped-entities",
+    "severity": 1,
+    "suggestions": null,
+  },
+  Object {
+    "column": 1,
+    "endColumn": null,
+    "endLine": null,
+    "fatal": true,
+    "line": 16,
+    "message": "Parsing error: \\"parserOptions.project\\" has been set for @typescript-eslint/parser.
+The file does not match your project config: test/fixtures/code-block.md/2.ts.
+The file must be included in at least one of the projects provided.",
+    "ruleId": null,
+    "severity": 1,
+    "suggestions": null,
+  },
+  Object {
+    "column": 1,
+    "endColumn": 6,
+    "endLine": 22,
+    "fix": Object {
+      "range": Array [
+        237,
+        242,
+      ],
+      "text": "# abc",
+    },
+    "line": 22,
+    "message": "Do not use headings with similar content (1:1)",
+    "nodeType": "Program",
+    "ruleId": "remark-lint-no-duplicate-headings",
+    "severity": 1,
+    "suggestions": null,
+  },
+  Object {
+    "column": 1,
+    "endColumn": 6,
+    "endLine": 22,
+    "fix": Object {
+      "range": Array [
+        237,
+        242,
+      ],
+      "text": "# abc",
+    },
+    "line": 22,
+    "message": "Don’t use multiple top level headings (1:1)",
+    "nodeType": "Program",
+    "ruleId": "remark-lint-no-multiple-toplevel-headings",
+    "severity": 1,
+    "suggestions": null,
+  },
+  Object {
+    "column": 8,
+    "endColumn": 13,
+    "endLine": 26,
+    "line": 26,
+    "message": "'React' is defined but never used.",
+    "messageId": "unusedVar",
+    "nodeType": "Identifier",
+    "ruleId": "no-unused-vars",
+    "severity": 1,
+    "suggestions": null,
+  },
+  Object {
+    "column": 1,
+    "endColumn": 6,
+    "endLine": 30,
+    "fix": Object {
+      "range": Array [
+        289,
+        294,
+      ],
+      "text": "# abc",
+    },
+    "line": 30,
+    "message": "Do not use headings with similar content (3:1)",
+    "nodeType": "Program",
+    "ruleId": "remark-lint-no-duplicate-headings",
+    "severity": 1,
+    "suggestions": null,
+  },
+  Object {
+    "column": 1,
+    "endColumn": 6,
+    "endLine": 30,
+    "fix": Object {
+      "range": Array [
+        289,
+        294,
+      ],
+      "text": "# abc",
+    },
+    "line": 30,
+    "message": "Don’t use multiple top level headings (3:1)",
+    "nodeType": "Program",
+    "ruleId": "remark-lint-no-multiple-toplevel-headings",
+    "severity": 1,
+    "suggestions": null,
+  },
+]
+`;
+
 exports[`fixtures should match all snapshots: details.mdx 1`] = `
 Array [
   Object {

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -12,13 +12,17 @@ const cli = new ESLint({
       sourceType: 'module',
     },
     extends: ['plugin:mdx/recommended'],
-    plugins: ['react', 'prettier'],
+    plugins: ['react', 'unicorn', 'prettier'],
+    rules: {
+      'mdx/code-block': 1,
+      'unicorn/prefer-spread': 2,
+    },
   },
 })
 
 describe('fixtures', () => {
   it('should match all snapshots', async () => {
-    const results = await cli.lintFiles(['test/fixtures/*.{md,mdx}'])
+    const results = await cli.lintFiles('test/fixtures/*.{md,mdx}')
     for (const { filePath, messages } of results) {
       expect(messages).toMatchSnapshot(path.basename(filePath))
     }

--- a/test/fixtures/code-block.md
+++ b/test/fixtures/code-block.md
@@ -1,0 +1,31 @@
+```JavaScript
+export var a = 1 == 2
+
+export const b = [].concat(a)
+```
+
+```log
+export var a = 1 == 2
+```
+
+```jsx
+export const App = () => <div>2 > 1</div>
+```
+
+```TypeScript
+export type Value = 1 | 2 | 3 | 4 | 5
+```
+
+```MarkDown
+# abc
+
+# abc
+```
+
+```mdx
+import React from 'react'
+
+# abc
+
+# abc
+```

--- a/test/helper.test.ts
+++ b/test/helper.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 
-import { getGlobals, requirePkg } from 'eslint-plugin-mdx'
+import { getGlobals, getRangeByLoc, requirePkg } from 'eslint-plugin-mdx'
 
 describe('Helpers', () => {
   it('should resolve globals correctly', () => {
@@ -22,4 +22,28 @@ describe('Helpers', () => {
 
   it('should throw on non existed package', () =>
     expect(() => requirePkg('@1stg/config', 'unexpected-')).toThrow())
+})
+
+describe('getRangeByLoc', () => {
+  it('should work as expected', () => {
+    expect(
+      getRangeByLoc(
+        `
+export const a = 1
+export const a = 1
+      `.trim(),
+        {
+          start: {
+            line: 2,
+            column: 8,
+          },
+          end: {
+            line: 2,
+            column: 15,
+          },
+        },
+      ),
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    ).toEqual([26, 33])
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
   },
   "ts-node": {
     "compilerOptions": {
-      "module": "commonjs",
-      "pretty": true
+      "module": "CommonJS"
     },
     "transpileOnly": true
   },


### PR DESCRIPTION
close #278

Using deprecated `CLIEngine#executeOnText` maybe not a good practice, I'll refactor to use preprocessor instead soon, but this version is working as expected already.

related https://github.com/eslint/eslint/issues/14203

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
