### PR TITLE
fix: read config from null

### DIFF
--- a/packages/eslint-plugin-mdx/src/rules/helpers.ts
+++ b/packages/eslint-plugin-mdx/src/rules/helpers.ts
@@ -72,7 +72,7 @@ export const getRemarkProcessor = (searchFrom: string, isMdx: boolean) => {
   }
 
   /* istanbul ignore next */
-  const { plugins = [], settings } = (result.config ||
+  const { plugins = [], settings } = (result?.config ||
     {}) as Partial<RemarkConfig>
 
   try {


### PR DESCRIPTION
Here's the type for `CosmiconfigResult`:

```ts
export declare type CosmiconfigResult = {
    config: Config;
    filepath: string;
    isEmpty?: boolean;
} | null;
```

I.e., the value of `result` could be `null`.

In case you want to take a look at the issue, here's the failed case https://github.com/webpack/webpack.js.org/pull/4326/checks?check_run_id=2126672107#step:7:16.