### PR TITLE
fix: resolves error caused when a remark config was not found

### DIFF
--- a/packages/eslint-plugin-mdx/src/rules/helpers.ts
+++ b/packages/eslint-plugin-mdx/src/rules/helpers.ts
@@ -70,9 +70,10 @@ export const getRemarkProcessor = (searchFrom: string, isMdx: boolean) => {
     }
   }
 
+  const config = result ? (result.config as Partial<RemarkConfig>) : {}
+
   /* istanbul ignore next */
-  const { plugins = [], settings } = (result?.config ||
-    {}) as Partial<RemarkConfig>
+  const { plugins = [], settings } = config
 
   try {
     // disable this rule automatically since we already have a parser option `extensions`


### PR DESCRIPTION
When using the latest version `1.10.0`, this plugin causes an error when a remark config can't be found:

```
Oops! Something went wrong! :(

ESLint: 7.22.0

TypeError: Cannot read property 'config' of null
```

This PR is a quick fix to properly set the fallback (`{}`) when a config isn't found.