### PR TITLE
fix: add helper getPositionAt to fix incorrect loc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
       // related to https://github.com/eslint/eslint/issues/14207
       rules: {
         'prettier/prettier': 0,
+        'react/no-unescaped-entities': 1,
         'unicorn/filename-case': 0,
       },
       settings: {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     ]
   },
   "typeCoverage": {
-    "atLeast": 99.7,
+    "atLeast": 99.92,
     "cache": true,
     "detail": true,
     "ignoreAsAssertion": true,

--- a/packages/eslint-mdx/src/helpers.ts
+++ b/packages/eslint-mdx/src/helpers.ts
@@ -95,7 +95,7 @@ export const getLinesFromCode = (code: string) => code.split('\n')
 // fix #292
 export const getLocFromRange = (
   lines: string[],
-  [start, end]: [number, number],
+  [start, end]: readonly [number, number],
 ): SourceLocation => {
   let offset = 0
 
@@ -146,16 +146,17 @@ export const restoreNodeLocation = <T>(
     return node
   }
 
-  const { range } = node
+  let {
+    range: [start, end],
+  } = node
 
-  const start = range[0] + offset
-  const end = range[1] + offset
+  const range = [(start += offset), (end += +offset)] as const
 
   return Object.assign(node, {
     start,
     end,
-    range: [start, end],
-    loc: getLocFromRange(lines, [start, end]),
+    range,
+    loc: getLocFromRange(lines, range),
   })
 }
 

--- a/packages/eslint-mdx/src/helpers.ts
+++ b/packages/eslint-mdx/src/helpers.ts
@@ -4,7 +4,13 @@ import type { Linter } from 'eslint'
 import type { Position as ESPosition, SourceLocation } from 'estree'
 import type { Point, Position } from 'unist'
 
-import type { Arrayable, JsxNode, ParserFn, ParserOptions } from './types'
+import type {
+  Arrayable,
+  JsxNode,
+  ParserFn,
+  ParserOptions,
+  ValueOf,
+} from './types'
 
 export const FALLBACK_PARSERS = [
   '@typescript-eslint/parser',
@@ -111,7 +117,7 @@ export const getPositionAt = (code: string, offset: number): ESPosition => {
 
 export const restoreNodeLocation = <T>(node: T, point: Point): T => {
   if (node && typeof node === 'object') {
-    for (const value of Object.values(node)) {
+    for (const value of Object.values(node) as Array<ValueOf<T>>) {
       restoreNodeLocation(value, point)
     }
   }

--- a/packages/eslint-mdx/src/parser.ts
+++ b/packages/eslint-mdx/src/parser.ts
@@ -371,13 +371,11 @@ export class Parser {
       throw e
     }
 
-    const offset = start - program.range[0]
-
     for (const prop of AST_PROPS)
       this._ast[prop].push(
         // ts doesn't understand the mixed type
         ...program[prop].map((item: never) =>
-          restoreNodeLocation(lines, item, offset),
+          restoreNodeLocation(lines, item, start),
         ),
       )
   }

--- a/packages/eslint-mdx/src/types.ts
+++ b/packages/eslint-mdx/src/types.ts
@@ -2,9 +2,19 @@ import type { JSXElement, JSXFragment } from '@babel/types'
 import type { AST, Linter } from 'eslint'
 import type { Node, Parent, Point } from 'unist'
 
-export type JsxNode = (JSXElement | JSXFragment) & { range: [number, number] }
-
 export type Arrayable<T> = T[] | readonly T[]
+
+export declare type ValueOf<T> = T extends {
+  [key: string]: infer M
+}
+  ? M
+  : T extends {
+      [key: number]: infer N
+    }
+  ? N
+  : never
+
+export type JsxNode = (JSXElement | JSXFragment) & { range: [number, number] }
 
 export type ParserFn = (
   code: string,

--- a/packages/eslint-plugin-mdx/src/processors/markdown.ts
+++ b/packages/eslint-plugin-mdx/src/processors/markdown.ts
@@ -242,7 +242,7 @@ function preprocess(text: string, filename: string): ESLinterProcessorFile[] {
 
   traverse(ast, {
     code(node, parent) {
-      const comments = []
+      const comments: string[] = []
 
       if (node.lang) {
         let index = parent.children.indexOf(node) - 1

--- a/packages/eslint-plugin-mdx/src/processors/types.ts
+++ b/packages/eslint-plugin-mdx/src/processors/types.ts
@@ -18,7 +18,7 @@ export interface ESLintProcessor<
 }
 
 export interface ESLintMdxSettings {
-  'mdx/code-blocks': boolean
+  'mdx/code-blocks'?: boolean
   'mdx/language-mapper'?: false | Record<string, string>
 }
 

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -109,6 +109,8 @@ Array [
 
 exports[`fixtures should match all snapshots: 287.mdx 1`] = `Array []`;
 
+exports[`fixtures should match all snapshots: 292.mdx 1`] = `Array []`;
+
 exports[`fixtures should match all snapshots: adjacent.mdx 1`] = `Array []`;
 
 exports[`fixtures should match all snapshots: basic.mdx 1`] = `Array []`;
@@ -231,7 +233,26 @@ exports[`fixtures should match all snapshots: markdown.md 1`] = `Array []`;
 
 exports[`fixtures should match all snapshots: no-jsx-html-comments.mdx 1`] = `Array []`;
 
-exports[`fixtures should match all snapshots: no-unescaped-entities.mdx 1`] = `Array []`;
+exports[`fixtures should match all snapshots: no-unescaped-entities.mdx 1`] = `
+Array [
+  Object {
+    "column": 8,
+    "line": 2,
+    "message": "\`>\` can be escaped with \`&gt;\`.",
+    "nodeType": "JSXText",
+    "ruleId": "react/no-unescaped-entities",
+    "severity": 1,
+  },
+  Object {
+    "column": 13,
+    "line": 5,
+    "message": "\`>\` can be escaped with \`&gt;\`.",
+    "nodeType": "JSXText",
+    "ruleId": "react/no-unescaped-entities",
+    "severity": 1,
+  },
+]
+`;
 
 exports[`fixtures should match all snapshots: processor.mdx 1`] = `
 Array [

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -172,6 +172,14 @@ Array [
     "severity": 1,
   },
   Object {
+    "column": 7,
+    "line": 35,
+    "message": "\`'\` can be escaped with \`&apos;\`, \`&lsquo;\`, \`&#39;\`, \`&rsquo;\`.",
+    "nodeType": "JSXText",
+    "ruleId": "react/no-unescaped-entities",
+    "severity": 1,
+  },
+  Object {
     "column": 2,
     "endColumn": 9,
     "endLine": 41,
@@ -223,7 +231,26 @@ Array [
 ]
 `;
 
-exports[`fixtures should match all snapshots: details.mdx 1`] = `Array []`;
+exports[`fixtures should match all snapshots: details.mdx 1`] = `
+Array [
+  Object {
+    "column": 290,
+    "line": 3,
+    "message": "\`'\` can be escaped with \`&apos;\`, \`&lsquo;\`, \`&#39;\`, \`&rsquo;\`.",
+    "nodeType": "JSXText",
+    "ruleId": "react/no-unescaped-entities",
+    "severity": 1,
+  },
+  Object {
+    "column": 5,
+    "line": 5,
+    "message": "\`'\` can be escaped with \`&apos;\`, \`&lsquo;\`, \`&#39;\`, \`&rsquo;\`.",
+    "nodeType": "JSXText",
+    "ruleId": "react/no-unescaped-entities",
+    "severity": 1,
+  },
+]
+`;
 
 exports[`fixtures should match all snapshots: jsx-in-list.mdx 1`] = `Array []`;
 

--- a/test/__snapshots__/helpers.test.ts.snap
+++ b/test/__snapshots__/helpers.test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Helpers should get correct loc range range 1`] = `
+Object {
+  "end": Object {
+    "column": 8,
+    "line": 1,
+  },
+  "start": Object {
+    "column": 2,
+    "line": 1,
+  },
+}
+`;
+
+exports[`Helpers should get correct loc range range 2`] = `
+Object {
+  "end": Object {
+    "column": 26,
+    "line": 4,
+  },
+  "start": Object {
+    "column": 19,
+    "line": 4,
+  },
+}
+`;

--- a/test/__snapshots__/helpers.test.ts.snap
+++ b/test/__snapshots__/helpers.test.ts.snap
@@ -2,26 +2,21 @@
 
 exports[`Helpers should get correct loc range range 1`] = `
 Object {
-  "end": Object {
-    "column": 8,
-    "line": 1,
-  },
-  "start": Object {
-    "column": 2,
-    "line": 1,
-  },
+  "column": 2,
+  "line": 1,
 }
 `;
 
 exports[`Helpers should get correct loc range range 2`] = `
 Object {
-  "end": Object {
-    "column": 26,
-    "line": 4,
-  },
-  "start": Object {
-    "column": 19,
-    "line": 4,
-  },
+  "column": 13,
+  "line": 4,
+}
+`;
+
+exports[`Helpers should get correct loc range range 3`] = `
+Object {
+  "column": 19,
+  "line": 4,
 }
 `;

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -15,6 +15,7 @@ const getCli = (lintCodeBlocks = false) =>
       extends: ['plugin:mdx/recommended'],
       plugins: ['react', 'unicorn', 'prettier'],
       rules: {
+        'react/no-unescaped-entities': 1,
         'unicorn/prefer-spread': 2,
       },
       overrides: lintCodeBlocks

--- a/test/fixtures/292.mdx
+++ b/test/fixtures/292.mdx
@@ -1,0 +1,8 @@
+# Header
+
+paragraph <div className="abc">content</div>
+
+- - <div kind="docs-packages-vuetify-preset" story="page">
+      Vuetify preset
+    </div>
+    : some extra text describing the preset

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 
-import { arrayify } from 'eslint-mdx'
+import { arrayify, getLinesFromCode, getLocFromRange } from 'eslint-mdx'
 import { getGlobals, getShortLang, requirePkg } from 'eslint-plugin-mdx'
 
 describe('Helpers', () => {
@@ -16,6 +16,33 @@ describe('Helpers', () => {
     expect(getShortLang('2.Markdown', false)).toBe('Markdown')
     expect(getShortLang('3.Markdown', { Markdown: 'mkdn' })).toBe('mkdn')
     expect(getShortLang('4.Markdown', { markdown: 'mkdn' })).toBe('mkdn')
+  })
+
+  it('should get correct loc range range', () => {
+    const code = `
+# Header
+
+- jsx in list <div>
+    <a href="link">content</a>
+  </div>
+    `.trim()
+    const lines = getLinesFromCode(code)
+    const headerWord = 'Header'
+    const contentWord = 'content'
+    const headerWordIndex = code.indexOf(headerWord)
+    const contentWordIndex = code.indexOf(contentWord)
+    expect(
+      getLocFromRange(lines, [
+        headerWordIndex,
+        headerWordIndex + headerWord.length,
+      ]),
+    ).toMatchSnapshot()
+    expect(
+      getLocFromRange(lines, [
+        contentWordIndex,
+        contentWordIndex + contentWord.length,
+      ]),
+    ).toMatchSnapshot()
   })
 
   it('should resolve globals correctly', () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 
-import { arrayify, getLinesFromCode, getLocFromRange } from 'eslint-mdx'
+import { arrayify, getPositionAt } from 'eslint-mdx'
 import { getGlobals, getShortLang, requirePkg } from 'eslint-plugin-mdx'
 
 describe('Helpers', () => {
@@ -26,23 +26,9 @@ describe('Helpers', () => {
     <a href="link">content</a>
   </div>
     `.trim()
-    const lines = getLinesFromCode(code)
-    const headerWord = 'Header'
-    const contentWord = 'content'
-    const headerWordIndex = code.indexOf(headerWord)
-    const contentWordIndex = code.indexOf(contentWord)
-    expect(
-      getLocFromRange(lines, [
-        headerWordIndex,
-        headerWordIndex + headerWord.length,
-      ]),
-    ).toMatchSnapshot()
-    expect(
-      getLocFromRange(lines, [
-        contentWordIndex,
-        contentWordIndex + contentWord.length,
-      ]),
-    ).toMatchSnapshot()
+    expect(getPositionAt(code, code.indexOf('Header'))).toMatchSnapshot()
+    expect(getPositionAt(code, code.indexOf('link'))).toMatchSnapshot()
+    expect(getPositionAt(code, code.indexOf('content'))).toMatchSnapshot()
   })
 
   it('should resolve globals correctly', () => {


### PR DESCRIPTION
close #292

The following has been resolved!

<del>
I don't know if there is a better and cleaner way without source `code` or `lines`.

---

OK, I found maybe we have to use this approach because the loc column of start node could be incorrect as described at https://github.com/mdx-js/eslint-mdx/issues/279#issuecomment-791531564, while the start offset is always correct.
</del>

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
