### PR TITLE
fix: result could be null in `plugins.reduce`

### DIFF
--- a/packages/eslint-plugin-mdx/src/rules/helpers.ts
+++ b/packages/eslint-plugin-mdx/src/rules/helpers.ts
@@ -75,12 +75,17 @@ export const getRemarkProcessor = (searchFrom: string, isMdx: boolean) => {
   const { plugins = [], settings } = (result?.config ||
     {}) as Partial<RemarkConfig>
 
-  try {
-    // disable this rule automatically since we already have a parser option `extensions`
-    // eslint-disable-next-line node/no-extraneous-require
-    plugins.push([require.resolve('remark-lint-file-extension'), false])
-  } catch {
-    // just ignore if the package does not exist
+  // disable this rule automatically since we already have a parser option `extensions`
+  // only disable this plugin if there are at least one plugin enabled
+  // otherwise `result` could be null inside `plugins.reduce`
+  /* istanbul ignore else */
+  if (plugins.length > 0) {
+    try {
+      // eslint-disable-next-line node/no-extraneous-require
+      plugins.push([require.resolve('remark-lint-file-extension'), false])
+    } catch {
+      // just ignore if the package does not exist
+    }
   }
 
   const initProcessor = remarkProcessor().use({ settings }).use(remarkStringify)


### PR DESCRIPTION
related to disable `remark-lint-file-extension` automatically

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
