### PR TITLE
refactor: traversal to use concrete node types where possible

### DIFF
--- a/packages/eslint-mdx/package.json
+++ b/packages/eslint-mdx/package.json
@@ -36,6 +36,7 @@
     "remark-mdx": "^1.6.22",
     "remark-parse": "^8.0.3",
     "tslib": "^2.3.0",
-    "unified": "^9.2.1"
+    "unified": "^9.2.1",
+    "unist-util-is": "^4.0.0"
   }
 }

--- a/packages/eslint-mdx/src/types.ts
+++ b/packages/eslint-mdx/src/types.ts
@@ -1,13 +1,20 @@
 import type { JSXElement, JSXFragment } from '@babel/types'
 import type { AST, Linter } from 'eslint'
-import type { Node as _Node, Parent as _Parent, Point } from 'unist'
+import type { Literal, Node, Parent, Point } from 'unist'
 
-export interface Node<T = string> extends _Node {
-  value?: T
+export { Node, Parent }
+export interface Jsx extends Literal {
+  type: 'jsx'
+  value: string
+}
+export interface Import extends Literal {
+  type: 'import'
+  value: string
 }
 
-export interface Parent<T = string> extends _Parent {
-  children: Array<Node<T>>
+export interface Export extends Literal {
+  type: 'export'
+  value: string
 }
 
 export type Arrayable<T> = T[] | readonly T[]

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import type { Node, Parent, ParserConfig, ParserOptions } from 'eslint-mdx'
+import type { Jsx, Node, Parent, ParserConfig, ParserOptions } from 'eslint-mdx'
 import {
   DEFAULT_PARSER_OPTIONS as parserOptions,
   first,
@@ -10,13 +10,14 @@ import {
 
 import { noop } from './helpers'
 
-const stringToNode = (text: string) =>
-  first((mdxProcessor.parse(text) as Parent).children)
+const stringToNode = (text: string): Jsx =>
+  first((mdxProcessor.parse(text) as Parent).children) as Jsx
 
 describe('parser', () => {
   it('should transform html style comment in jsx into jsx comment', () => {
     const sourceText = `<Comment><!-- JSX Comment --><!-- JSX Comment --></Comment>`
     const expectText = `<Comment>{/** JSX Comment */}{/** JSX Comment */}</Comment>`
+
     expect(parser.normalizeJsxNode(stringToNode(sourceText))).toEqual({
       type: 'jsx',
       data: {


### PR DESCRIPTION
Several parts of the code explicitly expect to work with `jsx`, `import`, or `export` nodes.
This refactors the code include typings for those three nodes, and leverages `unist-util-is` to assert the node types.
