### PR TITLE
fix: upgrade synckit v0.3.3 for node compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@1stg/lib-config": "^3.0.0",
     "@1stg/tslint-config": "^2.0.0",
-    "@types/eslint": "^7.2.14",
+    "@types/eslint": "^7.28.0",
     "@types/eslint-plugin-markdown": "^2.0.0",
     "@types/jest": "^26.0.24",
     "@types/node": "^16.3.1",

--- a/packages/eslint-plugin-mdx/package.json
+++ b/packages/eslint-plugin-mdx/package.json
@@ -39,7 +39,7 @@
     "remark-mdx": "^1.6.22",
     "remark-parse": "^8.0.3",
     "remark-stringify": "^8.1.1",
-    "synckit": "^0.2.0",
+    "synckit": "^0.3.3",
     "tslib": "^2.3.0",
     "unified": "^9.2.1",
     "vfile": "^4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,10 +2987,10 @@
     "@types/eslint" "*"
     "@types/unist" "*"
 
-"@types/eslint@*", "@types/eslint@^7.2.14":
-  version "7.2.14"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.14.tgz#088661518db0c3c23089ab45900b99dd9214b92a"
-  integrity sha512-pESyhSbUOskqrGcaN+bCXIQDyT5zTaRWfj5ZjjSlMatgGjIn3QQPfocAu4WSabUR7CGyLZ2CQaZyISOEX7/saw==
+"@types/eslint@*", "@types/eslint@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.28.0.tgz#7e41f2481d301c68e14f483fe10b017753ce8d5a"
+  integrity sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -11504,10 +11504,10 @@ synckit@^0.1.5:
     tslib "^2.2.0"
     uuid "^8.3.2"
 
-synckit@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.2.0.tgz#f42e6d37c1ec7e79c2b12e70f854f0e9519248d8"
-  integrity sha512-kbpgqlOu36aTFTWczzDk3I7Hf70V+BPGnUZ89z0RsLw666hpFf2m7/PS7OuNmDhazWaSJwv0LVBc2epyxSpl+w==
+synckit@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.3.3.tgz#a36af5d2f7382c9a2c5e528cd8ad64ed882dde70"
+  integrity sha512-uIPHDSdGBQS2C2PmFZkMhBYC20H0diioDEiOR1lsIoP25/xbJPHU0GdHJ7GgvAUkLgEkTJ32zNzulzIPnhrYZA==
   dependencies:
     tslib "^2.3.0"
     uuid "^8.3.2"


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->

We are still targeting Node 10 in v1. `synckit` will just use `child_process` as fallback when `worker_threads` is unavailable.