### PR TITLE
fix: allow comments to contain `--`

### DIFF
--- a/packages/eslint-mdx/src/regexp.ts
+++ b/packages/eslint-mdx/src/regexp.ts
@@ -23,7 +23,7 @@ export const openTag = '<[A-Za-z]*[A-Za-z0-9\\.\\-]*' + attribute + '*\\s*>'
 export const closeTag = '<\\s*\\/[A-Za-z]*[A-Za-z0-9\\.\\-]*\\s*>'
 export const selfClosingTag =
   '<[A-Za-z]*[A-Za-z0-9\\.\\-]*' + attribute + '*\\s*\\/?>'
-export const comment = '<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->'
+export const comment = '<!--(?:[^-]|-(?:[^-]|-+[^->]))*-*-->'
 export const commentOpen = '(<!---*)'
 export const commentClose = '(-*-->)'
 export const commentContent = `${commentOpen}([\\s\\S]*?)${commentClose}`

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -169,7 +169,18 @@ Array [
 ]
 `;
 
-exports[`fixtures should match all snapshots: comments.mdx 1`] = `Array []`;
+exports[`fixtures should match all snapshots: comments.mdx 1`] = `
+Array [
+  Object {
+    "column": 2,
+    "line": 1,
+    "message": "Unused eslint-disable directive (no problems were reported from 'no-console').",
+    "nodeType": null,
+    "ruleId": null,
+    "severity": 2,
+  },
+]
+`;
 
 exports[`fixtures should match all snapshots: details.mdx 1`] = `
 Array [

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -169,6 +169,8 @@ Array [
 ]
 `;
 
+exports[`fixtures should match all snapshots: comments.mdx 1`] = `Array []`;
+
 exports[`fixtures should match all snapshots: details.mdx 1`] = `
 Array [
   Object {

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -35,6 +35,7 @@ const getCli = (lintCodeBlocks = false) =>
           ]
         : [],
     },
+    reportUnusedDisableDirectives: 'error',
   })
 
 describe('fixtures', () => {

--- a/test/fixtures/comments.mdx
+++ b/test/fixtures/comments.mdx
@@ -1,0 +1,1 @@
+<!-- eslint-disable-next-line no-console -- Here's a description about why this configuration is necessary. -->


### PR DESCRIPTION
This change allows comments to contain `--`, which currently they can't, e.g.
```markdown
<!-- eslint-disable-next-line no-console -- Here's a description about why this configuration is necessary. -->
```
```
  1:1  error  Block is redundant  no-lone-blocks
```

I suspect this is already fixed in #284, by upgrading to [micromark](https://github.com/micromark/micromark). This PR adds a test and patches the comment regexp in the meantime.

remark-parse (where this regexp originally came from) [went directly](https://github.com/remarkjs/remark/commit/6b42465526bb15f70d98a0ea0daccea01ffb8004#diff-e74cdd04b8d016ea6e1f4e37bf73e8864f36de36a1409cf43a68dfaf70dfe0ffL13) from our current regexp to micromark, which [doesn't use](https://github.com/micromark/micromark/blob/main/packages/micromark-core-commonmark/dev/lib/html-flow.js) an equivalent.

I used the following to automatically construct this corrected, "strings that don't contain `-->`" regexp, substituting `aab` for `-->` because it [only allows](http://www.formauri.es/personal/pgimeno/misc/non-match-regex/?word=--%3E) alphanumerics, etc.: http://www.formauri.es/personal/pgimeno/misc/non-match-regex/?word=aab