### PR TITLE
feat: allow to ignore remark config

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ See [#251](https://github.com/mdx-js/eslint-mdx/issues/251#issuecomment-73613922
 
 3. `markdownExtensions` (`string | string[]`): `eslint-mdx` will only treat `.md` files as plain markdown by default, and will lint them via remark plugins. If you want to resolve other extensions as like `.md`, you can use this option.
 
+4. `ignoreRemarkConfig` (`boolean`): Ignore the `remark` configuration defined in the project.
+
 ## Rules
 
 ### mdx/no-jsx-html-comments
@@ -222,6 +224,8 @@ If you want to disable or change severity of some related rules, it won't work b
   ]
 }
 ```
+
+Some plugins are ESM and eslint don't supports them. So, a workaround is to set `ignoreRemarkConfig` to `true` and execute `remark-lint` through the terminal before running eslint. For example: `remark **/*.mdx --no-stdout && eslint . --fix --ext .mdx`.
 
 ## Prettier Integration
 

--- a/packages/eslint-mdx/README.md
+++ b/packages/eslint-mdx/README.md
@@ -190,6 +190,8 @@ See [#251](https://github.com/mdx-js/eslint-mdx/issues/251#issuecomment-73613922
 
 3. `markdownExtensions` (`string | string[]`): `eslint-mdx` will only treat `.md` files as plain markdown by default, and will lint them via remark plugins. If you want to resolve other extensions as like `.md`, you can use this option.
 
+4. `ignoreRemarkConfig` (`boolean`): Ignore the `remark` configuration defined in the project.
+
 ## Rules
 
 ### mdx/no-jsx-html-comments
@@ -222,6 +224,8 @@ If you want to disable or change severity of some related rules, it won't work b
   ]
 }
 ```
+
+Some plugins are ESM and eslint don't supports them. So, a workaround is to set `ignoreRemarkConfig` to `true` and execute `remark-lint` through the terminal before running eslint. For example: `remark **/*.mdx --no-stdout && eslint . --fix --ext .mdx`.
 
 ## Prettier Integration
 

--- a/packages/eslint-mdx/src/parser.ts
+++ b/packages/eslint-mdx/src/parser.ts
@@ -172,6 +172,7 @@ export class Parser {
     const root = getRemarkProcessor(
       getPhysicalFilename(options.filePath),
       isMdx,
+      Boolean(options.ignoreRemarkConfig),
     ).parse(code) as Parent
 
     this._ast = {

--- a/packages/eslint-mdx/src/processor.ts
+++ b/packages/eslint-mdx/src/processor.ts
@@ -70,7 +70,7 @@ const explorer = cosmiconfigSync('remark', {
 export const processorCache = new Map<string, FrozenProcessor>()
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
-export const getRemarkProcessor = (searchFrom: string, isMdx: boolean) => {
+export const getRemarkProcessor = (searchFrom: string, isMdx: boolean, ignoreRemarkConfig: boolean) => {
   const initCacheKey = `${String(isMdx)}-${searchFrom}`
 
   let cachedProcessor = processorCache.get(initCacheKey)
@@ -79,7 +79,10 @@ export const getRemarkProcessor = (searchFrom: string, isMdx: boolean) => {
     return cachedProcessor
   }
 
-  const result = explorer.search(searchFrom)
+  let result;
+  if (!ignoreRemarkConfig) {
+    result = explorer.search(searchFrom)
+  }
 
   const cacheKey = result ? `${String(isMdx)}-${result.filepath}` : ''
 

--- a/packages/eslint-mdx/src/processor.ts
+++ b/packages/eslint-mdx/src/processor.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import { cosmiconfigSync } from 'cosmiconfig'
+import type { CosmiconfigResult } from 'cosmiconfig/dist/types'
 import remarkMdx from 'remark-mdx'
 import remarkParse from 'remark-parse'
 import remarkStringify from 'remark-stringify'
@@ -69,8 +70,12 @@ const explorer = cosmiconfigSync('remark', {
 // @internal - exported for testing
 export const processorCache = new Map<string, FrozenProcessor>()
 
-// eslint-disable-next-line sonarjs/cognitive-complexity
-export const getRemarkProcessor = (searchFrom: string, isMdx: boolean, ignoreRemarkConfig: boolean) => {
+export const getRemarkProcessor = (
+  searchFrom: string,
+  isMdx: boolean,
+  ignoreRemarkConfig: boolean,
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+) => {
   const initCacheKey = `${String(isMdx)}-${searchFrom}`
 
   let cachedProcessor = processorCache.get(initCacheKey)
@@ -79,10 +84,9 @@ export const getRemarkProcessor = (searchFrom: string, isMdx: boolean, ignoreRem
     return cachedProcessor
   }
 
-  let result;
-  if (!ignoreRemarkConfig) {
-    result = explorer.search(searchFrom)
-  }
+  const result: CosmiconfigResult = ignoreRemarkConfig
+    ? null
+    : explorer.search(searchFrom)
 
   const cacheKey = result ? `${String(isMdx)}-${result.filepath}` : ''
 

--- a/packages/eslint-mdx/src/types.ts
+++ b/packages/eslint-mdx/src/types.ts
@@ -50,6 +50,7 @@ export interface ParserOptions extends Linter.ParserOptions {
   markdownExtensions?: string[] | string
   filePath?: string
   parser?: ParserConfig | ParserFn | string
+  ignoreRemarkConfig?: boolean
 }
 
 export type Traverser = (node: Node, parent?: Parent) => void

--- a/packages/eslint-plugin-mdx/src/rules/remark.ts
+++ b/packages/eslint-plugin-mdx/src/rules/remark.ts
@@ -25,6 +25,7 @@ const lazyRemark = {
       fileOptions: VFileOptions,
       physicalFilename: string,
       isMdx: boolean,
+      ignoreRemarkConfig: boolean,
     ) => {
       messages: VFile['messages']
       content: string
@@ -65,10 +66,16 @@ export const remark: Rule.RuleModule = {
           return
         }
 
+        const ignoreRemarkConfig = Boolean(options.ignoreRemarkConfig)
+
         const physicalFilename = getPhysicalFilename(filename)
 
         const sourceText = sourceCode.getText(node)
-        const remarkProcessor = getRemarkProcessor(physicalFilename, isMdx)
+        const remarkProcessor = getRemarkProcessor(
+          physicalFilename,
+          isMdx,
+          ignoreRemarkConfig,
+        )
 
         const fileOptions = {
           path: physicalFilename,
@@ -85,6 +92,7 @@ export const remark: Rule.RuleModule = {
             fileOptions,
             physicalFilename,
             isMdx,
+            ignoreRemarkConfig,
           )
           file.messages = messages
           fixedText = content
@@ -102,6 +110,7 @@ export const remark: Rule.RuleModule = {
                 fileOptions,
                 physicalFilename,
                 isMdx,
+                ignoreRemarkConfig,
               )
               file.messages = messages
               fixedText = content

--- a/packages/eslint-plugin-mdx/src/worker.ts
+++ b/packages/eslint-plugin-mdx/src/worker.ts
@@ -9,8 +9,13 @@ runAsWorker(
     fileOptions: VFileOptions,
     physicalFilename: string,
     isMdx: boolean,
+    ignoreRemarkConfig: boolean,
   ) => {
-    const remarkProcessor = getRemarkProcessor(physicalFilename, isMdx)
+    const remarkProcessor = getRemarkProcessor(
+      physicalFilename,
+      isMdx,
+      ignoreRemarkConfig,
+    )
     const file = vfile(fileOptions)
     try {
       await remarkProcessor.process(file)

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -13,8 +13,11 @@ import {
 
 const stringToNode = (text: string) =>
   first(
-    (getRemarkProcessor(PLACEHOLDER_FILE_PATH, true).parse(text) as Parent)
-      .children,
+    (
+      getRemarkProcessor(PLACEHOLDER_FILE_PATH, true, false).parse(
+        text,
+      ) as Parent
+    ).children,
   )
 
 describe('parser', () => {

--- a/test/remark.test.ts
+++ b/test/remark.test.ts
@@ -62,7 +62,6 @@ ruleTester.run('remark', remark, {
       filename: path.resolve(__dirname, 'fixtures/style/test.mdx'),
     },
   ],
-
   invalid: [
     {
       // https://github.com/syntax-tree/mdast-util-to-markdown/issues/29

--- a/test/remark.test.ts
+++ b/test/remark.test.ts
@@ -55,7 +55,14 @@ ruleTester.run('remark', remark, {
       parserOptions,
       filename: path.resolve(__dirname, 'fixtures/async/test.mdx'),
     },
+    {
+      code: '_emphasis_ and __strong__',
+      parser,
+      parserOptions: { ...parserOptions, ignoreRemarkConfig: true },
+      filename: path.resolve(__dirname, 'fixtures/style/test.mdx'),
+    },
   ],
+
   invalid: [
     {
       // https://github.com/syntax-tree/mdast-util-to-markdown/issues/29


### PR DESCRIPTION
This is just a proposal, and any kind of feedback is welcome.

I add a new `parserOption` named `ignoreRemarkConfig`. It can take two values: `true` or `false`. If it isn't defined, the value is treated as `false`.
What this does? It allow to ignore the remark config that is auto loaded.

Why this can be useful? I just try to improve the workaround commented in the following issue: https://github.com/mdx-js/eslint-mdx/issues/338#issuecomment-1059858710
If I have a remark config in my `package.json` that uses ESM plugins, I can't execute eslint because it throws an error. So, an alternative is to set the remark config in another place where it can't be autoloaded, then run remark, and, afterall, run eslint.

This is what I typically do:
```sh
# I set my remark config in `my_custom_remark_config.yml`.

# First of all, I run remark using my custom config file, that have ESM plugins:
yarn run remark **/*.mdx --no-stdout -r my_custom_remark_config.yml

# Then, I run eslint:
yarn run eslint . --fix --ext .mdx
```

I think this is very weird, so I purpose a way to keep the remark config where It should go. The biggest benefit is that I can save my configuration to package.json and avoid to have any more files in my project :smile:

If I set `ignoreRemarkConfig` to `true`, I just need to run:
```sh
yarn run remark **/*.mdx --no-stdout
yarn run eslint . --fix --ext .mdx
```
