### PR TITLE
fix: same markdown processor cached for .md and .mdx

### DIFF
--- a/packages/eslint-mdx/src/worker.ts
+++ b/packages/eslint-mdx/src/worker.ts
@@ -89,7 +89,9 @@ export const getRemarkProcessor = async (
     ? null
     : await explorer.search(searchFrom)
 
-  const cacheKey = result ? `${String(isMdx)}-${result.filepath}` : ''
+  const cacheKey = result
+    ? `${String(isMdx)}-${result.filepath}`
+    : String(isMdx)
 
   cachedProcessor = processorCache.get(cacheKey)
 


### PR DESCRIPTION
Closes #400 