### PR TITLE
feat: only enable `prettier/prettier` rule for `eslint-plugin-prettier` `<5.1.2`

### DIFF
--- a/.changeset/fifty-windows-sin.md
+++ b/.changeset/fifty-windows-sin.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-mdx": minor
+---
+
+feat: only enable `prettier/prettier` rule for `eslint-plugin-prettier` `<5.1.2`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
         run: |
           yarn lint
           yarn test
-        continue-on-error: ${{ matrix.os == 'windows-latest' }}
         env:
           EFF_NO_LINK_RULES: true
           PARSER_NO_WATCH: true

--- a/packages/eslint-plugin-mdx/src/configs/recommended.ts
+++ b/packages/eslint-plugin-mdx/src/configs/recommended.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import path from 'node:path'
 
 import type { ESLint, Linter } from 'eslint'
 
@@ -22,9 +23,19 @@ export const recommended: Linter.Config = {
 
 /* istanbul ignore next */
 // hack to bypass syntax error for commonjs
-const getImportMetaUrl = () =>
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-  new Function('return import.meta.url')() as string
+const getImportMetaUrl = () => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+    return new Function('return import.meta.url')() as string
+  } catch {
+    // if `--experimental-vm-modules` is not enabled, the following error would be thrown:
+    // `SyntaxError: Cannot use 'import.meta' outside a module`,
+    // then we fallback to `process.cwd()` resolution which could fail actually,
+    // but we're only trying to resolve `prettier` and `eslint-plugin-prettier` dependencies,
+    // it would be fine enough
+    return path.resolve(process.cwd(), '__test__.js')
+  }
+}
 
 /* istanbul ignore next */
 const cjsRequire =

--- a/packages/eslint-plugin-mdx/src/configs/recommended.ts
+++ b/packages/eslint-plugin-mdx/src/configs/recommended.ts
@@ -20,11 +20,13 @@ export const recommended: Linter.Config = {
   overrides,
 }
 
+/* istanbul ignore next */
 // hack to bypass syntax error for commonjs
 const getImportMetaUrl = () =>
   // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
   new Function('return import.meta.url')() as string
 
+/* istanbul ignore next */
 const cjsRequire =
   typeof require === 'undefined' ? createRequire(getImportMetaUrl()) : require
 
@@ -33,6 +35,8 @@ const addPrettierRules = () => {
     cjsRequire.resolve('prettier')
 
     const { meta } = cjsRequire('eslint-plugin-prettier') as ESLint.Plugin
+
+    /* istanbul ignore next */
     const version = meta?.version || ''
 
     /**
@@ -40,7 +44,9 @@ const addPrettierRules = () => {
      */
     const [major, minor, patch] = version.split('.')
 
+    /* istanbul ignore if -- We're using `eslint-plugin-prettier@4.2.1` for now */
     if (
+      /* istanbul ignore next */
       +major > 5 ||
       (+major === 5 &&
         (+minor > 1 || (+minor === 1 && Number.parseInt(patch) >= 2)))

--- a/packages/eslint-plugin-mdx/src/configs/recommended.ts
+++ b/packages/eslint-plugin-mdx/src/configs/recommended.ts
@@ -1,4 +1,6 @@
-import type { Linter } from 'eslint'
+import { createRequire } from 'node:module'
+
+import type { ESLint, Linter } from 'eslint'
 
 import { base } from './base'
 
@@ -18,31 +20,59 @@ export const recommended: Linter.Config = {
   overrides,
 }
 
-try {
-  require.resolve('prettier')
-  require.resolve('eslint-plugin-prettier')
-  overrides.push(
-    {
-      files: '*.md',
-      rules: {
-        'prettier/prettier': [
-          'error',
-          {
-            parser: 'markdown',
-          },
-        ],
+// hack to bypass syntax error for commonjs
+const getImportMetaUrl = () =>
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  new Function('return import.meta.url')() as string
+
+const cjsRequire =
+  typeof require === 'undefined' ? createRequire(getImportMetaUrl()) : require
+
+const addPrettierRules = () => {
+  try {
+    cjsRequire.resolve('prettier')
+
+    const { meta } = cjsRequire('eslint-plugin-prettier') as ESLint.Plugin
+    const version = meta?.version || ''
+
+    /**
+     * @see https://github.com/prettier/eslint-plugin-prettier/releases/tag/v5.1.2
+     */
+    const [major, minor, patch] = version.split('.')
+
+    if (
+      +major > 5 ||
+      (+major === 5 &&
+        (+minor > 1 || (+minor === 1 && Number.parseInt(patch) >= 2)))
+    ) {
+      return
+    }
+
+    overrides.push(
+      {
+        files: '*.md',
+        rules: {
+          'prettier/prettier': [
+            'error',
+            {
+              parser: 'markdown',
+            },
+          ],
+        },
       },
-    },
-    {
-      files: '*.mdx',
-      rules: {
-        'prettier/prettier': [
-          'error',
-          {
-            parser: 'mdx',
-          },
-        ],
+      {
+        files: '*.mdx',
+        rules: {
+          'prettier/prettier': [
+            'error',
+            {
+              parser: 'mdx',
+            },
+          ],
+        },
       },
-    },
-  )
-} catch {}
+    )
+  } catch {}
+}
+
+addPrettierRules()


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

https://github.com/prettier/eslint-plugin-prettier/releases/tag/v5.1.2

<!--do not edit: pr-->
