### PR TITLE
fix: incorrect docs due to prettier + mdx v2+ incompatible

### DIFF
--- a/.changeset/strange-balloons-turn.md
+++ b/.changeset/strange-balloons-turn.md
@@ -1,0 +1,6 @@
+---
+"eslint-mdx": patch
+"eslint-plugin-mdx": patch
+---
+
+fix: incorrect docs due to prettier + mdx v2+ incompatible

--- a/README.md
+++ b/README.md
@@ -163,8 +163,12 @@ See also <https://github.com/syntax-tree/mdast#code>
 
 A new `MDXHeading` estree node type is exported from `eslint-mdx` which represents markdown heading in `mdx` like the following:
 
+<!-- mdx v2+ incompatible -->
+<!-- prettier-ignore -->
 ```mdx
-<div># Here's a text gradient short code!</div>
+<div>
+# Here's a text gradient short code!
+</div>
 ```
 
 See also <https://github.com/syntax-tree/mdast#heading>

--- a/packages/eslint-mdx/README.md
+++ b/packages/eslint-mdx/README.md
@@ -163,8 +163,12 @@ See also <https://github.com/syntax-tree/mdast#code>
 
 A new `MDXHeading` estree node type is exported from `eslint-mdx` which represents markdown heading in `mdx` like the following:
 
+<!-- mdx v2+ incompatible -->
+<!-- prettier-ignore -->
 ```mdx
-<div># Here's a text gradient short code!</div>
+<div>
+# Here's a text gradient short code!
+</div>
 ```
 
 See also <https://github.com/syntax-tree/mdast#heading>

--- a/packages/eslint-plugin-mdx/README.md
+++ b/packages/eslint-plugin-mdx/README.md
@@ -163,8 +163,12 @@ See also <https://github.com/syntax-tree/mdast#code>
 
 A new `MDXHeading` estree node type is exported from `eslint-mdx` which represents markdown heading in `mdx` like the following:
 
+<!-- mdx v2+ incompatible -->
+<!-- prettier-ignore -->
 ```mdx
-<div># Here's a text gradient short code!</div>
+<div>
+# Here's a text gradient short code!
+</div>
 ```
 
 See also <https://github.com/syntax-tree/mdast#heading>


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

As title

<!--do not edit: pr-->
