### PR TITLE
fix: `position` could be `null` actually

### DIFF
--- a/.changeset/two-eagles-flash.md
+++ b/.changeset/two-eagles-flash.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-mdx": patch
+---
+
+fix: `position` could be `null` actually - related to #520

--- a/packages/eslint-plugin-mdx/src/rules/remark.ts
+++ b/packages/eslint-plugin-mdx/src/rules/remark.ts
@@ -72,7 +72,7 @@ export const remark: Rule.RuleModule = {
           fatal,
           line,
           column,
-          position: { start, end },
+          position,
         } of messages) {
           // https://github.com/remarkjs/remark-lint/issues/65#issuecomment-220800231
           /* istanbul ignore next */
@@ -82,6 +82,8 @@ export const remark: Rule.RuleModule = {
             // should never happen, just for robustness
             continue
           }
+
+          const { start, end } = position || {}
 
           const message: RemarkLintMessage = {
             reason,
@@ -96,11 +98,11 @@ export const remark: Rule.RuleModule = {
               line,
               // ! eslint ast column is 0-indexed, but unified is 1-indexed
               column: column - 1,
-              start: {
+              start: start && {
                 ...start,
                 column: start.column - 1,
               },
-              end: {
+              end: end && {
                 ...end,
                 column: end.column - 1,
               },

--- a/packages/eslint-plugin-mdx/src/rules/remark.ts
+++ b/packages/eslint-plugin-mdx/src/rules/remark.ts
@@ -83,7 +83,7 @@ export const remark: Rule.RuleModule = {
             continue
           }
 
-          const { start, end } = position || {}
+          const { start, end } = position || /* istanbul ignore next */ {}
 
           const message: RemarkLintMessage = {
             reason,


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://mdxjs.com/community/contribute/).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/community/support/
https://mdxjs.com/community/contribute/
-->

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/unifiedjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/unifiedjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/unifiedjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aunifiedjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

realted to #520

<!--do not edit: pr-->
