### PR TITLE
fix: code block filename regexp group names missed

### DIFF
--- a/.changeset/smart-pillows-hang.md
+++ b/.changeset/smart-pillows-hang.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-mdx": patch
+---
+
+fix: code block filename regexp group names missed

--- a/packages/eslint-plugin-mdx/src/processors/helpers.ts
+++ b/packages/eslint-plugin-mdx/src/processors/helpers.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_LANGUAGE_MAPPER: Record<string, string> = {
+export const DEFAULT_LANGUAGE_MAPPER = {
   ecmascript: 'js',
   javascript: 'js',
   javascriptreact: 'jsx',
@@ -9,7 +9,7 @@ export const DEFAULT_LANGUAGE_MAPPER: Record<string, string> = {
   markdownreact: 'mdx',
   mdown: 'md',
   mkdn: 'md',
-}
+} as const
 
 export function getShortLang(
   filename: string,
@@ -19,7 +19,13 @@ export function getShortLang(
   if (languageMapper === false) {
     return language
   }
-  languageMapper = { ...DEFAULT_LANGUAGE_MAPPER, ...languageMapper }
+  languageMapper = languageMapper
+    ? { ...DEFAULT_LANGUAGE_MAPPER, ...languageMapper }
+    : DEFAULT_LANGUAGE_MAPPER
+  const mapped = languageMapper[language]
+  if (mapped) {
+    return mapped
+  }
   const lang = language.toLowerCase()
-  return languageMapper[language] || languageMapper[lang] || lang
+  return languageMapper[lang] || lang
 }

--- a/packages/eslint-plugin-mdx/src/processors/types.ts
+++ b/packages/eslint-plugin-mdx/src/processors/types.ts
@@ -16,10 +16,8 @@ export interface RangeMap {
   md: number
 }
 
-export interface BlockBase {
+export interface CodeBlock extends Code {
   baseIndentText: string
   comments: string[]
   rangeMap: RangeMap[]
 }
-
-export interface Block extends Code, BlockBase {}

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -176,8 +176,8 @@ exports[`fixtures lint code blocks should work as expected: code-blocks/455.mdx 
     "endLine": 2,
     "fix": {
       "range": [
-        6,
-        9,
+        25,
+        28,
       ],
       "text": "let",
     },
@@ -194,8 +194,8 @@ exports[`fixtures lint code blocks should work as expected: code-blocks/455.mdx 
     "endLine": 4,
     "fix": {
       "range": [
-        13,
-        30,
+        32,
+        49,
       ],
       "text": "const b = [1, 2, 3]",
     },
@@ -212,8 +212,8 @@ exports[`fixtures lint code blocks should work as expected: code-blocks/455.mdx 
     "endLine": 6,
     "fix": {
       "range": [
-        43,
-        57,
+        62,
+        76,
       ],
       "text": ".at(-1)",
     },
@@ -228,7 +228,7 @@ exports[`fixtures lint code blocks should work as expected: code-blocks/455.mdx 
 `;
 
 exports[`fixtures lint code blocks should work as expected: code-blocks/455.mdx 2`] = `
-"\`\`\`js
+"\`\`\`js filename="test.js"
 let a
 
 const b = [1, 2, 3]

--- a/test/fixtures/code-blocks/455.mdx
+++ b/test/fixtures/code-blocks/455.mdx
@@ -1,4 +1,4 @@
-```js
+```js filename="test.js"
 var a
 
 let b = [1, 2, 3]


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Introduced by #550, it should be related to auto fixing

<!--do not edit: pr-->
