### PR TITLE
docs: remove blue underline from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
 <p align="center">
-  <a href="https://eslint.org">
-    <img src="https://eslint.org/icon.svg" height="50">
-  </a>
-  <a href="#readme">
-    <img src="https://rx-ts.github.io/assets/heart.svg" height="50">
-  </a>
-  <a href="https://github.com/mdx-js/mdx">
-    <img src="https://avatars.githubusercontent.com/u/37453691"  height="50">
-  </a>
+  <a href="https://eslint.org"><img src="https://eslint.org/icon.svg" height="50"></a>
+  <a href="#readme"><img src="https://rx-ts.github.io/assets/heart.svg" height="50"></a>
+  <a href="https://github.com/mdx-js/mdx"><img src="https://avatars.githubusercontent.com/u/37453691"  height="50"></a>
 </p>
 
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/mdx-js/eslint-mdx/ci.yml?branch=master)](https://github.com/mdx-js/eslint-mdx/actions/workflows/ci.yml?query=branch%3Amaster)

--- a/packages/eslint-mdx/README.md
+++ b/packages/eslint-mdx/README.md
@@ -1,13 +1,7 @@
 <p align="center">
-  <a href="https://eslint.org">
-    <img src="https://eslint.org/icon.svg" height="50">
-  </a>
-  <a href="#readme">
-    <img src="https://rx-ts.github.io/assets/heart.svg" height="50">
-  </a>
-  <a href="https://github.com/mdx-js/mdx">
-    <img src="https://avatars.githubusercontent.com/u/37453691"  height="50">
-  </a>
+  <a href="https://eslint.org"><img src="https://eslint.org/icon.svg" height="50"></a>
+  <a href="#readme"><img src="https://rx-ts.github.io/assets/heart.svg" height="50"></a>
+  <a href="https://github.com/mdx-js/mdx"><img src="https://avatars.githubusercontent.com/u/37453691"  height="50"></a>
 </p>
 
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/mdx-js/eslint-mdx/ci.yml?branch=master)](https://github.com/mdx-js/eslint-mdx/actions/workflows/ci.yml?query=branch%3Amaster)

--- a/packages/eslint-plugin-mdx/README.md
+++ b/packages/eslint-plugin-mdx/README.md
@@ -1,13 +1,7 @@
 <p align="center">
-  <a href="https://eslint.org">
-    <img src="https://eslint.org/icon.svg" height="50">
-  </a>
-  <a href="#readme">
-    <img src="https://rx-ts.github.io/assets/heart.svg" height="50">
-  </a>
-  <a href="https://github.com/mdx-js/mdx">
-    <img src="https://avatars.githubusercontent.com/u/37453691"  height="50">
-  </a>
+  <a href="https://eslint.org"><img src="https://eslint.org/icon.svg" height="50"></a>
+  <a href="#readme"><img src="https://rx-ts.github.io/assets/heart.svg" height="50"></a>
+  <a href="https://github.com/mdx-js/mdx"><img src="https://avatars.githubusercontent.com/u/37453691"  height="50"></a>
 </p>
 
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/mdx-js/eslint-mdx/ci.yml?branch=master)](https://github.com/mdx-js/eslint-mdx/actions/workflows/ci.yml?query=branch%3Amaster)


### PR DESCRIPTION
### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Documentation:
- Condense sponsor link markup in [README.md](https://github.com/react-hook-form/react-hook-form/blob/master/README.md) by collapsing `<a>` and `<img>` tags onto single lines to remove blue underlines from sponsor logos.

## Appearance

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/97992f40-be65-4e99-85cd-f492f0139616) | ![after](https://github.com/user-attachments/assets/3b24a235-b807-474f-b33d-3e7c21e6536f) |

<!--do not edit: pr-->
