### PR TITLE
feat: `eslint` 10 support

### DIFF
--- a/.changeset/legal-crabs-spend.md
+++ b/.changeset/legal-crabs-spend.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-mdx": minor
+---
+
+feat: `eslint` 10 support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         eslint:
           - 8
           - 9
+          - 10
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/packages/eslint-plugin-mdx/src/rules/remark.ts
+++ b/packages/eslint-plugin-mdx/src/rules/remark.ts
@@ -22,11 +22,13 @@ export const remark: Rule.RuleModule = {
     fixable: 'code',
   },
   create(context) {
-    // eslint-disable-next-line sonarjs/deprecation -- FIXME: ESLint 8.40+ required
-    const filename = context.getFilename()
+    const filename =
+      // eslint-disable-next-line sonarjs/deprecation -- FIXME: ESLint 8.40+ required
+      context.filename ?? /* istanbul ignore next */ context.getFilename()
     const extname = path.extname(filename)
-    // eslint-disable-next-line sonarjs/deprecation -- FIXME: ESLint 8.40+ required
-    const sourceCode = context.getSourceCode()
+    const sourceCode =
+      // eslint-disable-next-line sonarjs/deprecation -- FIXME: ESLint 8.40+ required
+      context.sourceCode ?? /* istanbul ignore next */ context.getSourceCode()
 
     /* istanbul ignore next */
     const {
@@ -61,7 +63,7 @@ export const remark: Rule.RuleModule = {
           filePath: getPhysicalFilename(filename),
           code: sourceText,
           // eslint-disable-next-line sonarjs/deprecation -- FIXME: ESLint 8.40+ required
-          cwd: context.getCwd(),
+          cwd: context.cwd ?? /* istanbul ignore next */ context.getCwd(),
           isMdx,
           process: true,
           ignoreRemarkConfig,


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

- **`packages/eslint-plugin-mdx/src/rules/remark.ts`**:
  - Refactored `context` property access to support both the [deprecated in ESLint v9 (and completely removed in ESLint v10)](https://eslint.org/docs/latest/use/migrate-to-10.0.0#-removal-of-deprecated-context-members) methods (`context.getSourceCode()`, `context.getFilename()`, `context.getCwd()`), and the new ESLint v9+ properties (`context.sourceCode`, `context.filename`, `context.cwd`).
  - `/* istanbul ignore next */` was used because the code handles backward compatibility for older versions of ESLint, which makes it difficult to test in a modern environment. Since `context.getSourceCode()` and similar methods is a standard, well-known deprecated API, the risk of it failing is near zero.

- **`.github/workflows/ci.yml`**:
  - Added `10` (ESLint v10) to the ESLint test matrix.

### Breaking Changes

None. This PR maintains backward compatibility with supported ESLint versions.

<!--do not edit: pr-->
