### PR TITLE
feat: enable `ecmaFeatures.jsx` in exported configs

### DIFF
--- a/.changeset/twelve-pots-push.md
+++ b/.changeset/twelve-pots-push.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-mdx": patch
+---
+
+Adds ecmaFeatures: { jsx: true } to premade configs

--- a/packages/eslint-plugin-mdx/src/configs/base.ts
+++ b/packages/eslint-plugin-mdx/src/configs/base.ts
@@ -5,6 +5,9 @@ export const base: Linter.LegacyConfig = {
   parserOptions: {
     sourceType: 'module',
     ecmaVersion: 'latest',
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
   plugins: ['mdx'],
   processor: 'mdx/remark',

--- a/packages/eslint-plugin-mdx/src/configs/flat.ts
+++ b/packages/eslint-plugin-mdx/src/configs/flat.ts
@@ -11,6 +11,11 @@ export const flat: Linter.FlatConfig = {
   files: ['**/*.{md,mdx}'],
   languageOptions: {
     parser: eslintMdx,
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
     globals: {
       React: false,
     },

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -1051,6 +1051,8 @@ exports[`fixtures should match all snapshots: esm/test.md 1`] = `
 ]
 `;
 
+exports[`fixtures should match all snapshots: jsx-imports.mdx 1`] = `[]`;
+
 exports[`fixtures should match all snapshots: jsx-in-list.mdx 1`] = `
 [
   {

--- a/test/__snapshots__/parser.test.ts.snap
+++ b/test/__snapshots__/parser.test.ts.snap
@@ -41599,6 +41599,1060 @@ exports[`parser should match all AST snapshots: comments.mdx 1`] = `"Unexpected 
 
 exports[`parser should match all AST snapshots: details.mdx 1`] = `"Expected a closing tag for \`<details>\` (1:1-1:10) before the end of \`paragraph\`"`;
 
+exports[`parser should match all AST snapshots: jsx-imports.mdx 1`] = `
+{
+  "body": [
+    {
+      "attributes": [],
+      "end": 29,
+      "loc": {
+        "end": {
+          "column": 29,
+          "line": 1,
+          "offset": 29,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "range": [
+        0,
+        29,
+      ],
+      "source": {
+        "end": 29,
+        "loc": {
+          "end": {
+            "column": 29,
+            "line": 1,
+            "offset": 29,
+          },
+          "start": {
+            "column": 21,
+            "line": 1,
+            "offset": 21,
+          },
+        },
+        "range": [
+          21,
+          29,
+        ],
+        "raw": "'./card'",
+        "start": 21,
+        "type": "Literal",
+        "value": "./card",
+      },
+      "specifiers": [
+        {
+          "end": 13,
+          "imported": {
+            "end": 13,
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 1,
+                "offset": 13,
+              },
+              "start": {
+                "column": 9,
+                "line": 1,
+                "offset": 9,
+              },
+            },
+            "name": "Card",
+            "range": [
+              9,
+              13,
+            ],
+            "start": 9,
+            "type": "Identifier",
+          },
+          "loc": {
+            "end": {
+              "column": 13,
+              "line": 1,
+              "offset": 13,
+            },
+            "start": {
+              "column": 9,
+              "line": 1,
+              "offset": 9,
+            },
+          },
+          "local": {
+            "end": 13,
+            "loc": {
+              "end": {
+                "column": 13,
+                "line": 1,
+                "offset": 13,
+              },
+              "start": {
+                "column": 9,
+                "line": 1,
+                "offset": 9,
+              },
+            },
+            "name": "Card",
+            "range": [
+              9,
+              13,
+            ],
+            "start": 9,
+            "type": "Identifier",
+          },
+          "range": [
+            9,
+            13,
+          ],
+          "start": 9,
+          "type": "ImportSpecifier",
+        },
+      ],
+      "start": 0,
+      "type": "ImportDeclaration",
+    },
+    {
+      "attributes": [],
+      "end": 63,
+      "loc": {
+        "end": {
+          "column": 33,
+          "line": 2,
+          "offset": 63,
+        },
+        "start": {
+          "column": 0,
+          "line": 2,
+          "offset": 30,
+        },
+      },
+      "range": [
+        30,
+        63,
+      ],
+      "source": {
+        "end": 63,
+        "loc": {
+          "end": {
+            "column": 33,
+            "line": 2,
+            "offset": 63,
+          },
+          "start": {
+            "column": 23,
+            "line": 2,
+            "offset": 53,
+          },
+        },
+        "range": [
+          53,
+          63,
+        ],
+        "raw": "'./button'",
+        "start": 53,
+        "type": "Literal",
+        "value": "./button",
+      },
+      "specifiers": [
+        {
+          "end": 45,
+          "imported": {
+            "end": 45,
+            "loc": {
+              "end": {
+                "column": 15,
+                "line": 2,
+                "offset": 45,
+              },
+              "start": {
+                "column": 9,
+                "line": 2,
+                "offset": 39,
+              },
+            },
+            "name": "Button",
+            "range": [
+              39,
+              45,
+            ],
+            "start": 39,
+            "type": "Identifier",
+          },
+          "loc": {
+            "end": {
+              "column": 15,
+              "line": 2,
+              "offset": 45,
+            },
+            "start": {
+              "column": 9,
+              "line": 2,
+              "offset": 39,
+            },
+          },
+          "local": {
+            "end": 45,
+            "loc": {
+              "end": {
+                "column": 15,
+                "line": 2,
+                "offset": 45,
+              },
+              "start": {
+                "column": 9,
+                "line": 2,
+                "offset": 39,
+              },
+            },
+            "name": "Button",
+            "range": [
+              39,
+              45,
+            ],
+            "start": 39,
+            "type": "Identifier",
+          },
+          "range": [
+            39,
+            45,
+          ],
+          "start": 39,
+          "type": "ImportSpecifier",
+        },
+      ],
+      "start": 30,
+      "type": "ImportDeclaration",
+    },
+    {
+      "end": 116,
+      "expression": {
+        "children": [
+          {
+            "children": [
+              {
+                "end": 99,
+                "loc": {
+                  "end": {
+                    "column": 18,
+                    "line": 7,
+                  },
+                  "start": {
+                    "column": 10,
+                    "line": 7,
+                  },
+                },
+                "range": [
+                  91,
+                  99,
+                ],
+                "raw": "Click me",
+                "start": 91,
+                "type": "JSXText",
+                "value": "Click me",
+              },
+            ],
+            "closingElement": {
+              "end": 108,
+              "loc": {
+                "end": {
+                  "column": 27,
+                  "line": 7,
+                },
+                "start": {
+                  "column": 18,
+                  "line": 7,
+                },
+              },
+              "name": {
+                "end": 107,
+                "loc": {
+                  "end": {
+                    "column": 26,
+                    "line": 7,
+                  },
+                  "start": {
+                    "column": 20,
+                    "line": 7,
+                  },
+                },
+                "name": "Button",
+                "range": [
+                  101,
+                  107,
+                ],
+                "raw": "Button",
+                "start": 101,
+                "type": "JSXIdentifier",
+              },
+              "range": [
+                99,
+                108,
+              ],
+              "raw": "</Button>",
+              "start": 99,
+              "type": "JSXClosingElement",
+            },
+            "end": 108,
+            "loc": {
+              "end": {
+                "column": 27,
+                "line": 7,
+              },
+              "start": {
+                "column": 2,
+                "line": 7,
+              },
+            },
+            "openingElement": {
+              "attributes": [],
+              "end": 91,
+              "loc": {
+                "end": {
+                  "column": 10,
+                  "line": 7,
+                },
+                "start": {
+                  "column": 2,
+                  "line": 7,
+                },
+              },
+              "name": {
+                "end": 90,
+                "loc": {
+                  "end": {
+                    "column": 9,
+                    "line": 7,
+                  },
+                  "start": {
+                    "column": 3,
+                    "line": 7,
+                  },
+                },
+                "name": "Button",
+                "range": [
+                  84,
+                  90,
+                ],
+                "raw": "Button",
+                "start": 84,
+                "type": "JSXIdentifier",
+              },
+              "range": [
+                83,
+                91,
+              ],
+              "raw": "<Button>",
+              "selfClosing": false,
+              "start": 83,
+              "type": "JSXOpeningElement",
+            },
+            "range": [
+              83,
+              108,
+            ],
+            "raw": "<Button>Click me</Button>",
+            "start": 83,
+            "type": "JSXElement",
+          },
+        ],
+        "closingElement": {
+          "end": 116,
+          "loc": {
+            "end": {
+              "column": 7,
+              "line": 8,
+            },
+            "start": {
+              "column": 0,
+              "line": 8,
+            },
+          },
+          "name": {
+            "end": 115,
+            "loc": {
+              "end": {
+                "column": 6,
+                "line": 8,
+              },
+              "start": {
+                "column": 2,
+                "line": 8,
+              },
+            },
+            "name": "Card",
+            "range": [
+              111,
+              115,
+            ],
+            "raw": "Card",
+            "start": 111,
+            "type": "JSXIdentifier",
+          },
+          "range": [
+            109,
+            116,
+          ],
+          "raw": "</Card>",
+          "start": 109,
+          "type": "JSXClosingElement",
+        },
+        "end": 116,
+        "loc": {
+          "end": {
+            "column": 7,
+            "line": 8,
+          },
+          "start": {
+            "column": 0,
+            "line": 6,
+          },
+        },
+        "openingElement": {
+          "attributes": [],
+          "end": 80,
+          "loc": {
+            "end": {
+              "column": 6,
+              "line": 6,
+            },
+            "start": {
+              "column": 0,
+              "line": 6,
+            },
+          },
+          "name": {
+            "end": 79,
+            "loc": {
+              "end": {
+                "column": 5,
+                "line": 6,
+              },
+              "start": {
+                "column": 1,
+                "line": 6,
+              },
+            },
+            "name": "Card",
+            "range": [
+              75,
+              79,
+            ],
+            "raw": "Card",
+            "start": 75,
+            "type": "JSXIdentifier",
+          },
+          "range": [
+            74,
+            80,
+          ],
+          "raw": "<Card>",
+          "selfClosing": false,
+          "start": 74,
+          "type": "JSXOpeningElement",
+        },
+        "range": [
+          74,
+          116,
+        ],
+        "raw": "<Card>
+  <Button>Click me</Button>
+</Card>",
+        "start": 74,
+        "type": "JSXElement",
+      },
+      "loc": {
+        "end": {
+          "column": 8,
+          "line": 8,
+          "offset": 116,
+        },
+        "start": {
+          "column": 1,
+          "line": 6,
+          "offset": 74,
+        },
+      },
+      "range": [
+        74,
+        116,
+      ],
+      "start": 74,
+      "type": "ExpressionStatement",
+    },
+  ],
+  "comments": [],
+  "end": 117,
+  "loc": {
+    "end": {
+      "column": 1,
+      "line": 9,
+      "offset": 117,
+    },
+    "start": {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "range": [
+    0,
+    117,
+  ],
+  "sourceType": undefined,
+  "start": 0,
+  "tokens": [
+    {
+      "end": 6,
+      "loc": {
+        "end": {
+          "column": 6,
+          "line": 1,
+          "offset": 6,
+        },
+        "start": {
+          "column": 0,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "range": [
+        0,
+        6,
+      ],
+      "start": 0,
+      "type": "Keyword",
+      "value": "import",
+    },
+    {
+      "end": 8,
+      "loc": {
+        "end": {
+          "column": 8,
+          "line": 1,
+          "offset": 8,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+          "offset": 7,
+        },
+      },
+      "range": [
+        7,
+        8,
+      ],
+      "start": 7,
+      "type": "Punctuator",
+      "value": "{",
+    },
+    {
+      "end": 13,
+      "loc": {
+        "end": {
+          "column": 13,
+          "line": 1,
+          "offset": 13,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+          "offset": 9,
+        },
+      },
+      "range": [
+        9,
+        13,
+      ],
+      "start": 9,
+      "type": "Identifier",
+      "value": "Card",
+    },
+    {
+      "end": 15,
+      "loc": {
+        "end": {
+          "column": 15,
+          "line": 1,
+          "offset": 15,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+          "offset": 14,
+        },
+      },
+      "range": [
+        14,
+        15,
+      ],
+      "start": 14,
+      "type": "Punctuator",
+      "value": "}",
+    },
+    {
+      "end": 20,
+      "loc": {
+        "end": {
+          "column": 20,
+          "line": 1,
+          "offset": 20,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+          "offset": 16,
+        },
+      },
+      "range": [
+        16,
+        20,
+      ],
+      "start": 16,
+      "type": "Identifier",
+      "value": "from",
+    },
+    {
+      "end": 29,
+      "loc": {
+        "end": {
+          "column": 29,
+          "line": 1,
+          "offset": 29,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+          "offset": 21,
+        },
+      },
+      "range": [
+        21,
+        29,
+      ],
+      "start": 21,
+      "type": "String",
+      "value": "'./card'",
+    },
+    {
+      "end": 36,
+      "loc": {
+        "end": {
+          "column": 6,
+          "line": 2,
+          "offset": 36,
+        },
+        "start": {
+          "column": 0,
+          "line": 2,
+          "offset": 30,
+        },
+      },
+      "range": [
+        30,
+        36,
+      ],
+      "start": 30,
+      "type": "Keyword",
+      "value": "import",
+    },
+    {
+      "end": 38,
+      "loc": {
+        "end": {
+          "column": 8,
+          "line": 2,
+          "offset": 38,
+        },
+        "start": {
+          "column": 7,
+          "line": 2,
+          "offset": 37,
+        },
+      },
+      "range": [
+        37,
+        38,
+      ],
+      "start": 37,
+      "type": "Punctuator",
+      "value": "{",
+    },
+    {
+      "end": 45,
+      "loc": {
+        "end": {
+          "column": 15,
+          "line": 2,
+          "offset": 45,
+        },
+        "start": {
+          "column": 9,
+          "line": 2,
+          "offset": 39,
+        },
+      },
+      "range": [
+        39,
+        45,
+      ],
+      "start": 39,
+      "type": "Identifier",
+      "value": "Button",
+    },
+    {
+      "end": 47,
+      "loc": {
+        "end": {
+          "column": 17,
+          "line": 2,
+          "offset": 47,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+          "offset": 46,
+        },
+      },
+      "range": [
+        46,
+        47,
+      ],
+      "start": 46,
+      "type": "Punctuator",
+      "value": "}",
+    },
+    {
+      "end": 52,
+      "loc": {
+        "end": {
+          "column": 22,
+          "line": 2,
+          "offset": 52,
+        },
+        "start": {
+          "column": 18,
+          "line": 2,
+          "offset": 48,
+        },
+      },
+      "range": [
+        48,
+        52,
+      ],
+      "start": 48,
+      "type": "Identifier",
+      "value": "from",
+    },
+    {
+      "end": 63,
+      "loc": {
+        "end": {
+          "column": 33,
+          "line": 2,
+          "offset": 63,
+        },
+        "start": {
+          "column": 23,
+          "line": 2,
+          "offset": 53,
+        },
+      },
+      "range": [
+        53,
+        63,
+      ],
+      "start": 53,
+      "type": "String",
+      "value": "'./button'",
+    },
+    {
+      "end": 72,
+      "loc": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "range": [
+        67,
+        72,
+      ],
+      "start": 67,
+      "type": "JSXText",
+      "value": "Hello",
+    },
+    {
+      "end": 75,
+      "loc": {
+        "end": {
+          "column": 1,
+          "line": 6,
+        },
+        "start": {
+          "column": 0,
+          "line": 6,
+        },
+      },
+      "range": [
+        74,
+        75,
+      ],
+      "start": 74,
+      "type": "Punctuator",
+      "value": "<",
+    },
+    {
+      "end": 79,
+      "loc": {
+        "end": {
+          "column": 5,
+          "line": 6,
+        },
+        "start": {
+          "column": 1,
+          "line": 6,
+        },
+      },
+      "range": [
+        75,
+        79,
+      ],
+      "start": 75,
+      "type": "JSXIdentifier",
+      "value": "Card",
+    },
+    {
+      "end": 84,
+      "loc": {
+        "end": {
+          "column": 3,
+          "line": 7,
+        },
+        "start": {
+          "column": 2,
+          "line": 7,
+        },
+      },
+      "range": [
+        83,
+        84,
+      ],
+      "start": 83,
+      "type": "Punctuator",
+      "value": "<",
+    },
+    {
+      "end": 90,
+      "loc": {
+        "end": {
+          "column": 9,
+          "line": 7,
+        },
+        "start": {
+          "column": 3,
+          "line": 7,
+        },
+      },
+      "range": [
+        84,
+        90,
+      ],
+      "start": 84,
+      "type": "JSXIdentifier",
+      "value": "Button",
+    },
+    {
+      "end": 99,
+      "loc": {
+        "end": {
+          "column": 18,
+          "line": 7,
+        },
+        "start": {
+          "column": 10,
+          "line": 7,
+        },
+      },
+      "range": [
+        91,
+        99,
+      ],
+      "start": 91,
+      "type": "JSXText",
+      "value": "Click me",
+    },
+    {
+      "end": 100,
+      "loc": {
+        "end": {
+          "column": 19,
+          "line": 7,
+        },
+        "start": {
+          "column": 18,
+          "line": 7,
+        },
+      },
+      "range": [
+        99,
+        100,
+      ],
+      "start": 99,
+      "type": "Punctuator",
+      "value": "<",
+    },
+    {
+      "end": 101,
+      "loc": {
+        "end": {
+          "column": 20,
+          "line": 7,
+        },
+        "start": {
+          "column": 19,
+          "line": 7,
+        },
+      },
+      "range": [
+        100,
+        101,
+      ],
+      "start": 100,
+      "type": "Punctuator",
+      "value": "/",
+    },
+    {
+      "end": 107,
+      "loc": {
+        "end": {
+          "column": 26,
+          "line": 7,
+        },
+        "start": {
+          "column": 20,
+          "line": 7,
+        },
+      },
+      "range": [
+        101,
+        107,
+      ],
+      "start": 101,
+      "type": "JSXIdentifier",
+      "value": "Button",
+    },
+    {
+      "end": 108,
+      "loc": {
+        "end": {
+          "column": 27,
+          "line": 7,
+        },
+        "start": {
+          "column": 26,
+          "line": 7,
+        },
+      },
+      "range": [
+        107,
+        108,
+      ],
+      "start": 107,
+      "type": "Punctuator",
+      "value": ">",
+    },
+    {
+      "end": 110,
+      "loc": {
+        "end": {
+          "column": 1,
+          "line": 8,
+        },
+        "start": {
+          "column": 0,
+          "line": 8,
+        },
+      },
+      "range": [
+        109,
+        110,
+      ],
+      "start": 109,
+      "type": "Punctuator",
+      "value": "<",
+    },
+    {
+      "end": 111,
+      "loc": {
+        "end": {
+          "column": 2,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 8,
+        },
+      },
+      "range": [
+        110,
+        111,
+      ],
+      "start": 110,
+      "type": "Punctuator",
+      "value": "/",
+    },
+    {
+      "end": 115,
+      "loc": {
+        "end": {
+          "column": 6,
+          "line": 8,
+        },
+        "start": {
+          "column": 2,
+          "line": 8,
+        },
+      },
+      "range": [
+        111,
+        115,
+      ],
+      "start": 111,
+      "type": "JSXIdentifier",
+      "value": "Card",
+    },
+    {
+      "end": 116,
+      "loc": {
+        "end": {
+          "column": 7,
+          "line": 8,
+        },
+        "start": {
+          "column": 6,
+          "line": 8,
+        },
+      },
+      "range": [
+        115,
+        116,
+      ],
+      "start": 115,
+      "type": "Punctuator",
+      "value": ">",
+    },
+  ],
+  "type": "Program",
+}
+`;
+
 exports[`parser should match all AST snapshots: jsx-in-list.mdx 1`] = `
 {
   "body": [

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 
 import eslintJs from '@eslint/js'
 import { TSESLint } from '@typescript-eslint/utils'
+import { Linter } from 'eslint'
 import prettierRecommended from 'eslint-plugin-prettier/recommended'
 import react from 'eslint-plugin-react'
 import globals from 'globals'
@@ -11,6 +12,7 @@ import { config, configs } from 'typescript-eslint'
 import * as mdx from 'eslint-plugin-mdx'
 
 const fixturesDir = path.resolve('test/fixtures')
+const eslintMajor = Number(new Linter().version.split('.')[0])
 
 const getCli = (lintCodeBlocks = false, fix?: boolean) => {
   const remarkConfigPath = path.resolve(
@@ -34,6 +36,11 @@ const getCli = (lintCodeBlocks = false, fix?: boolean) => {
           lintCodeBlocks,
         }),
         languageOptions: {
+          parserOptions: {
+            ecmaFeatures: {
+              jsx: true,
+            },
+          },
           globals: globals.node,
         },
         settings: {
@@ -52,7 +59,6 @@ const getCli = (lintCodeBlocks = false, fix?: boolean) => {
           'prefer-const': 'error',
           'react/jsx-curly-brace-presence': 'error',
           'react/self-closing-comp': 'error',
-          'no-unused-vars': 'error',
         },
       },
       {
@@ -112,10 +118,25 @@ describe('fixtures', () => {
     ONE_MINUTE,
   )
 
-  it(
+  /* eslint-disable jest/no-standalone-expect */
+  const itOnESLint10 = eslintMajor >= 10 ? it : it.skip
+  itOnESLint10(
     'should not report no-unused-vars for JSX component imports in MDX',
     async () => {
-      const cli = getCli()
+      // Uses only the plugin's built-in flat config without any user-land
+      // ecmaFeatures.jsx override, to verify the plugin sets it by default
+      const cli = new TSESLint.ESLint({
+        overrideConfigFile: true,
+        overrideConfig: [
+          eslintJs.configs.recommended,
+          mdx.configs.flat,
+          mdx.configs.flatCodeBlocks,
+          {
+            files: ['**/*.{md,mdx}'],
+            rules: { 'no-unused-vars': 'error' },
+          },
+        ],
+      })
 
       const results = await cli.lintFiles(
         path.join(fixturesDir, 'jsx-imports.mdx'),
@@ -130,6 +151,7 @@ describe('fixtures', () => {
     },
     ONE_MINUTE,
   )
+  /* eslint-enable */
 
   describe('lint code blocks', () => {
     it(

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -12,7 +12,7 @@ import { config, configs } from 'typescript-eslint'
 import * as mdx from 'eslint-plugin-mdx'
 
 const fixturesDir = path.resolve('test/fixtures')
-const eslintMajor = Number(new Linter().version.split('.')[0])
+const isEslint10 = Number.parseInt(Linter.version, 10) >= 10
 
 const getCli = (lintCodeBlocks = false, fix?: boolean) => {
   const remarkConfigPath = path.resolve(
@@ -118,40 +118,32 @@ describe('fixtures', () => {
     ONE_MINUTE,
   )
 
-  /* eslint-disable jest/no-standalone-expect */
-  const itOnESLint10 = eslintMajor >= 10 ? it : it.skip
-  itOnESLint10(
-    'should not report no-unused-vars for JSX component imports in MDX',
-    async () => {
-      // Uses only the plugin's built-in flat config without any user-land
-      // ecmaFeatures.jsx override, to verify the plugin sets it by default
-      const cli = new TSESLint.ESLint({
-        overrideConfigFile: true,
-        overrideConfig: [
-          eslintJs.configs.recommended,
-          mdx.configs.flat,
-          mdx.configs.flatCodeBlocks,
-          {
-            files: ['**/*.{md,mdx}'],
-            rules: { 'no-unused-vars': 'error' },
-          },
-        ],
-      })
+  const test = isEslint10 ? it : it.skip
 
-      const results = await cli.lintFiles(
-        path.join(fixturesDir, 'jsx-imports.mdx'),
-      )
+  test('should not report no-unused-vars for JSX component imports in MDX', async () => {
+    // Uses only the plugin's built-in flat config without any user-land
+    // ecmaFeatures.jsx override, to verify the plugin sets it by default
+    const cli = new TSESLint.ESLint({
+      overrideConfigFile: true,
+      overrideConfig: [
+        mdx.configs.flat,
+        mdx.configs.flatCodeBlocks,
+        {
+          files: ['**/*.{md,mdx}'],
+          rules: { 'no-unused-vars': 'error' },
+        },
+      ],
+    })
 
-      const messages = results.flatMap(r => r.messages)
-      const unusedVarsMessages = messages.filter(
-        m => m.ruleId === 'no-unused-vars',
-      )
+    const results = await cli.lintFiles(
+      path.join(fixturesDir, 'jsx-imports.mdx'),
+    )
 
-      expect(unusedVarsMessages).toEqual([])
-    },
-    ONE_MINUTE,
-  )
-  /* eslint-enable */
+    const messages = results.flatMap(r => r.messages)
+
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(messages).toEqual([])
+  })
 
   describe('lint code blocks', () => {
     it(

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -34,11 +34,6 @@ const getCli = (lintCodeBlocks = false, fix?: boolean) => {
           lintCodeBlocks,
         }),
         languageOptions: {
-          parserOptions: {
-            ecmaFeatures: {
-              jsx: true,
-            },
-          },
           globals: globals.node,
         },
         settings: {
@@ -57,6 +52,7 @@ const getCli = (lintCodeBlocks = false, fix?: boolean) => {
           'prefer-const': 'error',
           'react/jsx-curly-brace-presence': 'error',
           'react/self-closing-comp': 'error',
+          'no-unused-vars': 'error',
         },
       },
       {
@@ -112,6 +108,25 @@ describe('fixtures', () => {
           expect(output).toMatchSnapshot(relative(filePath))
         }
       }
+    },
+    ONE_MINUTE,
+  )
+
+  it(
+    'should not report no-unused-vars for JSX component imports in MDX',
+    async () => {
+      const cli = getCli()
+
+      const results = await cli.lintFiles(
+        path.join(fixturesDir, 'jsx-imports.mdx'),
+      )
+
+      const messages = results.flatMap(r => r.messages)
+      const unusedVarsMessages = messages.filter(
+        m => m.ruleId === 'no-unused-vars',
+      )
+
+      expect(unusedVarsMessages).toEqual([])
     },
     ONE_MINUTE,
   )

--- a/test/fixtures/jsx-imports.mdx
+++ b/test/fixtures/jsx-imports.mdx
@@ -1,0 +1,8 @@
+import { Card } from './card'
+import { Button } from './button'
+
+# Hello
+
+<Card>
+  <Button>Click me</Button>
+</Card>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4562,14 +4562,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
-  version: 1.0.9
-  resolution: "@types/estree@npm:1.0.9"
-  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:1.0.8":
+"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -4713,12 +4706,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 25.9.1
-  resolution: "@types/node@npm:25.9.1"
+"@types/node@npm:*, @types/node@npm:^22.0.0, @types/node@npm:^22.16.0":
+  version: 22.19.19
+  resolution: "@types/node@npm:22.19.19"
   dependencies:
-    undici-types: "npm:>=7.24.0 <7.24.7"
-  checksum: 10c0/9a04682842bebbcf21a1779dfeab9aa733d7bd7bbc0a0edb641ab3a9a3d43eac543225acf669c334f458f1956443ebc072bc3c72840c543b8b356cab5c82d456
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/402e0f088c94cabda3cd721546bd8e4e75e098e0b342f6e03b90ca1e19c28986f9650112c64fcfd09fc8cebc0f8b20291a513153e90489331cf666e1e5503e16
   languageName: node
   linkType: hard
 
@@ -4726,15 +4719,6 @@ __metadata:
   version: 12.20.55
   resolution: "@types/node@npm:12.20.55"
   checksum: 10c0/3b190bb0410047d489c49bbaab592d2e6630de6a50f00ba3d7d513d59401d279972a8f5a598b5bb8ddc1702f8a2f4ec57a65d93852f9c329639738e7053637d1
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^22.0.0, @types/node@npm:^22.16.0":
-  version: 22.19.19
-  resolution: "@types/node@npm:22.19.19"
-  dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10c0/402e0f088c94cabda3cd721546bd8e4e75e098e0b342f6e03b90ca1e19c28986f9650112c64fcfd09fc8cebc0f8b20291a513153e90489331cf666e1e5503e16
   languageName: node
   linkType: hard
 
@@ -4972,17 +4956,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ungap/structured-clone@npm:1.3.0":
+"@ungap/structured-clone@npm:1.3.0, @ungap/structured-clone@npm:^1.0.0, @ungap/structured-clone@npm:^1.3.0":
   version: 1.3.0
   resolution: "@ungap/structured-clone@npm:1.3.0"
   checksum: 10c0/0fc3097c2540ada1fc340ee56d58d96b5b536a2a0dab6e3ec17d4bfc8c4c86db345f61a375a8185f9da96f01c69678f836a2b57eeaa9e4b8eeafd26428e57b0a
-  languageName: node
-  linkType: hard
-
-"@ungap/structured-clone@npm:^1.0.0, @ungap/structured-clone@npm:^1.3.0":
-  version: 1.3.1
-  resolution: "@ungap/structured-clone@npm:1.3.1"
-  checksum: 10c0/7e75faf93cf12ff07c3d15a9e4d326b68f57d13f7246d9f4df2c1ed1a5cde581f899d397816ba5d5d703a0d7f6219e4408f385160156cf20b4e082721817cc37
   languageName: node
   linkType: hard
 
@@ -6475,17 +6452,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"comment-parser@npm:1.4.6":
+"comment-parser@npm:1.4.6, comment-parser@npm:^1.4.0, comment-parser@npm:^1.4.1":
   version: 1.4.6
   resolution: "comment-parser@npm:1.4.6"
   checksum: 10c0/10837626fc1cb84531564a5ec145f5818b3830393c09744ebfea4105319824e277bdb60ffcf38f44e165e002909fda835b21e20d032a8f8d068834aaef8af0ca
-  languageName: node
-  linkType: hard
-
-"comment-parser@npm:^1.4.0, comment-parser@npm:^1.4.1":
-  version: 1.4.7
-  resolution: "comment-parser@npm:1.4.7"
-  checksum: 10c0/09a8e6cc4a9f92e8828bbd8819d8b025cb1bf03d8d611e372627380f55b6401bb0009cf1b7940a028794f150891bfe855185b94173eb89f14b824e847335278d
   languageName: node
   linkType: hard
 
@@ -14980,13 +14950,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:>=7.24.0 <7.24.7":
-  version: 7.24.6
-  resolution: "undici-types@npm:7.24.6"
-  checksum: 10c0/d9cd8befb643ac904615c280a095ba4240531f6bb4a5e75a22a7483630ca8d3f1016d2ab6ace6ceda1f63b3a2db2fe037fafe121d6917a0187573aa548ff78ca
-  languageName: node
-  linkType: hard
-
 "undici-types@npm:~6.21.0":
   version: 6.21.0
   resolution: "undici-types@npm:6.21.0"
@@ -15317,16 +15280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:*":
-  version: 14.0.0
-  resolution: "uuid@npm:14.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
-  languageName: node
-  linkType: hard
-
-"uuid@npm:13.0.0":
+"uuid@npm:*, uuid@npm:13.0.0":
   version: 13.0.0
   resolution: "uuid@npm:13.0.0"
   bin:


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Adds `ecmaFeatures: { jsx: true }` to the premade configs for mdx files so that ESLint 10 can [identify & track JSX references](https://eslint.org/docs/latest/use/migrate-to-10.0.0#-jsx-references-are-now-tracked) in MDX files.

Closes #444 for ESLint 10 users