### PR TITLE
fix: actually run CI actually on ESLint 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,11 @@ jobs:
         run: yarn --immutable
 
       - name: Install ESLint ${{ matrix.eslint }}
+        run: yarn add -D eslint@${{ matrix.eslint }} @types/eslint@9
+
+      - name: Pin ESLint 8 plugin resolutions
         if: ${{ matrix.eslint < 9 }}
-        run: |
-          yarn add -D eslint@${{ matrix.eslint }} @types/eslint@9
-          yarn set resolution eslint-plugin-unicorn-x@npm:eslint-plugin-unicorn@^59.0.1 npm:eslint-plugin-unicorn@^56
+        run: yarn set resolution eslint-plugin-unicorn-x@npm:eslint-plugin-unicorn@^59.0.1 npm:eslint-plugin-unicorn@^56
 
       - name: Build, Lint and Test
         run: |


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

ESLint 10 was added to the CI matrix in #602 but due to a conditional in the CI step that actually installs eslint 

https://github.com/mdx-js/eslint-mdx/blob/f717ff284a5fb8c6cf3c99318d0a1316686b9c8f/.github/workflows/ci.yml#L45-L48

it was never installed and the tests did not actually run on that ESLint major version

The tests do not pass on ESLint 10 when they’re actually run there, notably because:
- `eslint-plugin-react` does not support ESLint 10 (used in testing configs) 
- the version of `@typescript-eslint/utils` that’s installed via `@1stg/common-config` does not support ESLint 10

I would probably recommend
- adding overrides for `typescript-eslint` packages in CI when ESLint 10 is running
- moving from the legacy `eslint-plugin-react` to the more modern & maintained [`@eslint-react/eslint-plugin`](https://github.com/rel1cx/eslint-react/)
    - You’d have to stay on 2.x here to keep support for testing ESLint 8 though

I don’t have time to do this migration work myself to make the tests pass so I will mark this PR back to draft

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)
