### PR TITLE
chore: restore better node compatibility

### DIFF
--- a/.changeset/slick-icons-tickle.md
+++ b/.changeset/slick-icons-tickle.md
@@ -1,0 +1,5 @@
+---
+"eslint-mdx": patch
+---
+
+chore: restore better node compatibility

--- a/packages/eslint-mdx/src/tokens.ts
+++ b/packages/eslint-mdx/src/tokens.ts
@@ -1,6 +1,6 @@
 /// <reference types="remark-mdx" />
 
-import { ok as assert } from 'node:assert/strict'
+import { strict as assert } from 'node:assert'
 
 import type { Token, TokenType, tokTypes } from 'acorn'
 import type { Root } from 'mdast'
@@ -56,15 +56,15 @@ export const restoreTokens = (
 
     const nodePos = node.position
 
-    assert(nodePos)
+    assert.ok(nodePos)
 
     const nodeStart = nodePos.start.offset
     const nodeEnd = nodePos.end.offset
 
     const lastCharOffset = prevCharOffset(nodeEnd - 2)
 
-    assert(nodeStart != null)
-    assert(nodeEnd != null)
+    assert.ok(nodeStart != null)
+    assert.ok(nodeEnd != null)
 
     if (node.type === 'mdxFlowExpression') {
       tokens.push(
@@ -92,7 +92,7 @@ export const restoreTokens = (
     if (nodeName) {
       nodeNameStart = nextCharOffset(nodeStart + 1)
 
-      assert(nodeNameStart)
+      assert.ok(nodeNameStart)
 
       tokens.push(
         newToken(
@@ -110,17 +110,17 @@ export const restoreTokens = (
     for (const attr of node.attributes) {
       // already handled by acorn
       if (attr.type === 'mdxJsxExpressionAttribute') {
-        assert(attr.data)
-        assert(attr.data.estree)
-        assert(attr.data.estree.range)
+        assert.ok(attr.data)
+        assert.ok(attr.data.estree)
+        assert.ok(attr.data.estree.range)
 
         let [attrValStart, attrValEnd] = attr.data.estree.range
 
         attrValStart = prevCharOffset(attrValStart - 1)
         attrValEnd = nextCharOffset(attrValEnd)
 
-        assert(text[attrValStart] === '{')
-        assert(text[attrValEnd] === '}')
+        assert.ok(text[attrValStart] === '{')
+        assert.ok(text[attrValEnd] === '}')
 
         lastAttrOffset = attrValEnd
 
@@ -145,7 +145,7 @@ export const restoreTokens = (
 
       const attrStart = nextCharOffset(lastAttrOffset + 1)
 
-      assert(attrStart != null)
+      assert.ok(attrStart != null)
 
       const attrName = attr.name
       const attrNameLength = attrName.length
@@ -165,7 +165,7 @@ export const restoreTokens = (
 
       const attrEqualOffset = nextCharOffset(attrStart + attrNameLength)
 
-      assert(text[attrEqualOffset] === '=')
+      assert.ok(text[attrEqualOffset] === '=')
 
       tokens.push(newToken(tt.eq, attrEqualOffset, attrEqualOffset + 1, '='))
 
@@ -178,8 +178,8 @@ export const restoreTokens = (
         attrValStart = prevCharOffset(attrValStart - 1)
         attrValEnd = nextCharOffset(attrValEnd)
 
-        assert(text[attrValStart] === '{')
-        assert(text[attrValEnd] === '}')
+        assert.ok(text[attrValStart] === '{')
+        assert.ok(text[attrValEnd] === '}')
 
         lastAttrOffset = attrValEnd
 
@@ -195,7 +195,7 @@ export const restoreTokens = (
 
       const attrQuote = text[attrQuoteOffset]
 
-      assert(attrQuote === '"' || attrQuote === "'")
+      assert.ok(attrQuote === '"' || attrQuote === "'")
 
       tokens.push(
         newToken(
@@ -208,7 +208,7 @@ export const restoreTokens = (
 
       lastAttrOffset = nextCharOffset(attrQuoteOffset + attrValue.length + 1)
 
-      assert(text[lastAttrOffset] === attrQuote)
+      assert.ok(text[lastAttrOffset] === attrQuote)
     }
 
     let nextOffset = nextCharOffset(lastAttrOffset + 1)
@@ -224,7 +224,7 @@ export const restoreTokens = (
     if (selfClosing) {
       tokens.push(newToken(tt.slash, nextOffset, nextOffset + 1, '/'))
     } else {
-      assert(
+      assert.ok(
         nextChar === '>',
         `\`nextChar\` must be '>' but actually is '${nextChar}'`,
       )
@@ -244,13 +244,13 @@ export const restoreTokens = (
 
       const slashOffset = prevCharOffset(prevOffset - nodeNameLength)
 
-      assert(text[slashOffset] === '/')
+      assert.ok(text[slashOffset] === '/')
 
       tokens.push(newToken(tt.slash, slashOffset, slashOffset + 1, '/'))
 
       const tagStartOffset = prevCharOffset(slashOffset - 1)
 
-      assert(text[tagStartOffset] === '<')
+      assert.ok(text[tagStartOffset] === '<')
 
       tokens.push(newToken(tt.jsxTagStart, tagStartOffset, tagStartOffset + 1))
     }

--- a/packages/eslint-mdx/src/worker.ts
+++ b/packages/eslint-mdx/src/worker.ts
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/no-await-expression-member */
 
-import { ok as assert } from 'node:assert/strict'
+import { strict as assert } from 'node:assert'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
@@ -224,7 +224,7 @@ export const getRemarkProcessor = async (
 function isExpressionStatement(
   statement: Program['body'][number],
 ): asserts statement is ExpressionStatement | undefined {
-  assert(!statement || statement.type === 'ExpressionStatement')
+  assert.ok(!statement || statement.type === 'ExpressionStatement')
 }
 
 runAsWorker(
@@ -420,7 +420,7 @@ runAsWorker(
                 if (child.data && 'estree' in child.data && child.data.estree) {
                   const { estree } = child.data
 
-                  assert(estree.body.length <= 1)
+                  assert.ok(estree.body.length <= 1)
 
                   const statement = estree.body[0]
 
@@ -538,12 +538,12 @@ runAsWorker(
             if (!selfClosing) {
               const prevOffset = prevCharOffset(lastCharOffset)
               const slashOffset = prevCharOffset(prevOffset - nodeNameLength)
-              assert(
+              assert.ok(
                 code[slashOffset] === '/',
                 `expect \`${code[slashOffset]}\` to be \`/\`, the node is ${node.name}`,
               )
               const tagStartOffset = prevCharOffset(slashOffset - 1)
-              assert(code[tagStartOffset] === '<')
+              assert.ok(code[tagStartOffset] === '<')
               closingElement = {
                 ...normalizeNode(tagStartOffset, nodeEnd),
                 type: 'JSXClosingElement',
@@ -559,17 +559,17 @@ runAsWorker(
                 name: handleJsxName(node.name, nodeNameStart),
                 attributes: node.attributes.map(attr => {
                   if (attr.type === 'mdxJsxExpressionAttribute') {
-                    assert(attr.data)
-                    assert(attr.data.estree)
-                    assert(attr.data.estree.range)
+                    assert.ok(attr.data)
+                    assert.ok(attr.data.estree)
+                    assert.ok(attr.data.estree.range)
 
                     let [attrValStart, attrValEnd] = attr.data.estree.range
 
                     attrValStart = prevCharOffset(attrValStart - 1)
                     attrValEnd = nextCharOffset(attrValEnd)
 
-                    assert(code[attrValStart] === '{')
-                    assert(code[attrValEnd] === '}')
+                    assert.ok(code[attrValStart] === '{')
+                    assert.ok(code[attrValEnd] === '}')
 
                     lastAttrOffset = attrValEnd
 
@@ -589,7 +589,7 @@ runAsWorker(
 
                   const attrStart = nextCharOffset(lastAttrOffset + 1)
 
-                  assert(attrStart != null)
+                  assert.ok(attrStart != null)
 
                   const attrName = attr.name
                   const attrNameLength = attrName.length
@@ -617,7 +617,7 @@ runAsWorker(
                     attrStart + attrNameLength,
                   )
 
-                  assert(code[attrEqualOffset] === '=')
+                  assert.ok(code[attrEqualOffset] === '=')
 
                   let attrValuePos: NormalPosition
 
@@ -626,13 +626,13 @@ runAsWorker(
 
                     const attrQuote = code[attrQuoteOffset]
 
-                    assert(attrQuote === '"' || attrQuote === "'")
+                    assert.ok(attrQuote === '"' || attrQuote === "'")
 
                     lastAttrOffset = nextCharOffset(
                       attrQuoteOffset + attrValue.length + 1,
                     )
 
-                    assert(code[lastAttrOffset] === attrQuote)
+                    assert.ok(code[lastAttrOffset] === attrQuote)
 
                     attrValuePos = normalizeNode(
                       attrQuoteOffset,
@@ -646,8 +646,8 @@ runAsWorker(
                     attrValStart = prevCharOffset(attrValStart - 1)
                     attrValEnd = nextCharOffset(attrValEnd)
 
-                    assert(code[attrValStart] === '{')
-                    assert(code[attrValEnd] === '}')
+                    assert.ok(code[attrValStart] === '{')
+                    assert.ok(code[attrValEnd] === '}')
 
                     lastAttrOffset = attrValEnd
 
@@ -695,7 +695,7 @@ runAsWorker(
               nextChar = code[nextOffset]
             }
 
-            assert(
+            assert.ok(
               nextChar === expectedNextChar,
               `\`nextChar\` must be '${expectedNextChar}' but actually is '${nextChar}'`,
             )


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://mdxjs.com/community/support/ -->
* [x] I read the contributing guide <!-- https://mdxjs.com/community/contribute/ -->
* [x] I agree to follow the code of conduct <!-- https://github.com/mdx-js/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Amdx-js&type=issues and https://github.com/orgs/mdx-js/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

Follow up #600 which breaks Node 14 compatibility unexpectedly although we announced Node 18+ required. Mostly for `eslint-plugin-prettier`.

<!--do not edit: pr-->
