### PR TITLE
fix: support ESLint config inspector

### DIFF
--- a/.changeset/full-teams-help.md
+++ b/.changeset/full-teams-help.md
@@ -1,0 +1,5 @@
+---
+"eslint-plugin-mdx": patch
+---
+
+fix: support ESLint config inspector

--- a/package.json
+++ b/package.json
@@ -74,9 +74,6 @@
       ".ts",
       ".tsx"
     ],
-    "setupFiles": [
-      "<rootDir>/node_modules/eslint/lib/linter/linter.js"
-    ],
     "snapshotSerializers": [
       "<rootDir>/test/jest.serializer.cjs"
     ],

--- a/packages/eslint-plugin-mdx/src/configs/flat.ts
+++ b/packages/eslint-plugin-mdx/src/configs/flat.ts
@@ -8,6 +8,7 @@ import { codeBlocks } from './code-blocks.js'
 
 // eslint-disable-next-line sonarjs/deprecation
 export const flat: Linter.FlatConfig = {
+  name: 'mdx/flat',
   files: ['**/*.{md,mdx}'],
   languageOptions: {
     parser: eslintMdx,
@@ -35,6 +36,7 @@ const { parserOptions, ...restConfig } = codeBlocks
 
 // eslint-disable-next-line sonarjs/deprecation
 export const flatCodeBlocks: Linter.FlatConfig = {
+  name: 'mdx/flat-code-blocks',
   files: ['**/*.{md,mdx}/**'],
   languageOptions: {
     parserOptions,

--- a/packages/eslint-plugin-mdx/src/processors/options.ts
+++ b/packages/eslint-plugin-mdx/src/processors/options.ts
@@ -16,16 +16,11 @@ const linterPath = Object.keys(cjsRequire.cache).find(path =>
   /([/\\])eslint\1lib(?:\1linter){2}\.js$/.test(path),
 )
 
-/* istanbul ignore if */
-if (!linterPath) {
-  throw new Error('Could not find ESLint Linter in require cache')
-}
-
 export interface LinterConfig extends ESLint.Linter.Config {
   extractConfig?(filename?: string): ESLint.Linter.Config
 }
 
-const ESLinter = cjsRequire<typeof ESLint>(linterPath).Linter
+const ESLinter = cjsRequire<typeof ESLint>(linterPath || 'eslint').Linter
 
 // patch Linter#verify
 


### PR DESCRIPTION
## Summary
- Fall back to importing ESLint when its internal Linter module is not already in the require cache.
- Add names to the exported flat configs for clearer config inspector output.
- Remove the Jest setup preload that was only needed for the old cache requirement.

Closes #598

## Test plan
- [x] Pre-commit hook: `eslint --cache --fix`
- [x] Pre-commit hook: `tsc -p tsconfig.base.json --noEmit`
- [x] Pre-commit hook: `type-coverage -p tsconfig.base.json`